### PR TITLE
Run pipeline on Jenkins master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,14 +1,13 @@
-elifeLibrary {
-    def isNew
-    def candidateVersion
-    def commit
-
-    stage 'Checkout', {
-        checkout scm
-        commit = elifeGitRevision()
-    }
-
+elifePipeline {
     node('containers-jenkins-plugin') {
+        def isNew
+        def candidateVersion
+        def commit
+
+        stage 'Checkout', { checkout scm
+            commit = elifeGitRevision()
+        }
+
         stage 'Build images', {
             checkout scm
             dockerComposeBuild(commit)


### PR DESCRIPTION
`elifeLibrary` runs the pipeline in a `elife-libraries--ci` node, that can be a bottleneck as there's a single one of them. `elifePipeline` runs this on the Jenkins master, which has 8 executors.

We then basically run the whole build on `containers` nodes that can autoscale, so it makes little difference in terms of load to the Jenkins master.