### PR TITLE
removed httplib2 and oauth2client dependency

### DIFF
--- a/requirements.prereq.txt
+++ b/requirements.prereq.txt
@@ -1,3 +1,1 @@
-httplib2==0.9.2
-oauth2client==3.0.0
 apache_beam[gcp]==2.9.0


### PR DESCRIPTION
We're not using it directly and shouldn't need to maintain the version separately.