### PR TITLE
changed travis language to generic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-language: python
+language: generic
 
 services:
   - docker


### PR DESCRIPTION
With the language `python`, travis was installing the dependencies separately - now using Python 3. We are using Docker and don't want to install them separately.