### PR TITLE
extend TEI to JATS mapping, including body, figures, tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ dev-venv:
 
 
 build-dev:
-	if [ "$(NO_BUILD)" != "y" ]; then \
+	@if [ "$(NO_BUILD)" != "y" ]; then \
 		$(DOCKER_COMPOSE) build sciencebeam-base-dev sciencebeam-dev; \
 	fi
 
@@ -31,7 +31,11 @@ test: build-dev
 
 
 watch: build-dev
-	$(RUN_DEV) pytest-watch -- -p no:cacheprovider $(PYTEST_ARGS)
+	$(RUN_DEV) pytest-watch --verbose --ext=.py,.xsl -- -p no:cacheprovider $(PYTEST_ARGS)
+
+
+shell-dev: build-dev
+	$(RUN_DEV) bash
 
 
 ci-build-all:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -10,6 +10,7 @@ services:
         volumes:
         - ./sciencebeam:/srv/sciencebeam/sciencebeam
         - ./tests:/srv/sciencebeam/tests
+        - ./xslt:/srv/sciencebeam/xslt
         environment:
             # avoid issues with .pyc/pyo files when mounting source directory
             PYTHONOPTIMIZE: ""

--- a/tests/transformers/grobid_jats_xslt_test.py
+++ b/tests/transformers/grobid_jats_xslt_test.py
@@ -519,6 +519,36 @@ class TestGrobidJatsXslt(object):
             assert _get_text(jats, 'body/sec/p/xref/@ref-type') == 'fig'
             assert _get_text(jats, 'body/sec/p/xref/@rid') == 'fig_0'
 
+        def test_should_extract_tables(self, grobid_jats_xslt):
+            jats = etree.fromstring(grobid_jats_xslt(
+                _tei(body=E.body(
+                    E.div(
+                        E.p(E.ref('(Table 1)', type='table', target='#tab_0'))
+                    ),
+                    E.figure(
+                        {
+                            'type': 'table',
+                            XML_ID: 'tab_0'
+                        },
+                        E.head('Table 1'),
+                        E.label('1'),
+                        E.figDesc('Table 1. This is a table'),
+                        E.table('Table content')
+                    )
+                ))
+            ))
+            assert _get_text(jats, 'body/sec/table-wrap/@id') == 'tab_0'
+            assert _get_text(jats, 'body/sec/table-wrap/label') == 'Table 1'
+            assert _get_text(jats, 'body/sec/table-wrap/caption/p') == 'Table 1. This is a table'
+            assert _get_item(jats, 'body/sec/table-wrap/table') is not None
+            assert _get_item(jats, 'body/sec/table-wrap/table/tbody') is not None
+            assert _get_item(jats, 'body/sec/table-wrap/table/tbody/tr') is not None
+            assert _get_item(jats, 'body/sec/table-wrap/table/tbody/tr/td') is not None
+            assert _get_text(jats, 'body/sec/table-wrap/table/tbody/tr/td') == 'Table content'
+            assert _get_text(jats, 'body/sec/p/xref') == '(Table 1)'
+            assert _get_text(jats, 'body/sec/p/xref/@ref-type') == 'table'
+            assert _get_text(jats, 'body/sec/p/xref/@rid') == 'tab_0'
+
         def test_should_extract_bibr_ref(self, grobid_jats_xslt):
             jats = etree.fromstring(grobid_jats_xslt(
                 _tei(body=E.body(E.div(

--- a/tests/transformers/grobid_jats_xslt_test.py
+++ b/tests/transformers/grobid_jats_xslt_test.py
@@ -519,6 +519,26 @@ class TestGrobidJatsXslt(object):
             assert _get_text(jats, 'body/sec/p/xref/@ref-type') == 'fig'
             assert _get_text(jats, 'body/sec/p/xref/@rid') == 'fig_0'
 
+        def test_should_extract_bibr_ref(self, grobid_jats_xslt):
+            jats = etree.fromstring(grobid_jats_xslt(
+                _tei(body=E.body(E.div(
+                    E.p(E.ref('Some ref', type='bibr', target='#b0'))
+                )))
+            ))
+            assert _get_text(jats, 'body/sec/p') == 'Some ref'
+            assert _get_text(jats, 'body/sec/p/xref') == 'Some ref'
+            assert _get_text(jats, 'body/sec/p/xref/@ref-type') == 'bibr'
+            assert _get_text(jats, 'body/sec/p/xref/@rid') == 'b0'
+
+        def test_should_extract_bibr_ref_without_target_as_text(self, grobid_jats_xslt):
+            jats = etree.fromstring(grobid_jats_xslt(
+                _tei(body=E.body(E.div(
+                    E.p(E.ref('Some ref', type='bibr'))
+                )))
+            ))
+            assert _get_text(jats, 'body/sec/p') == 'Some ref'
+            assert not jats.xpath('body/sec/p/xref')
+
         def test_should_extract_unknown_ref_as_text(self, grobid_jats_xslt):
             jats = etree.fromstring(grobid_jats_xslt(
                 _tei(body=E.body(E.div(

--- a/tests/transformers/grobid_jats_xslt_test.py
+++ b/tests/transformers/grobid_jats_xslt_test.py
@@ -513,6 +513,7 @@ class TestGrobidJatsXslt(object):
             assert _get_text(jats, 'body/sec/fig/@id') == 'fig_0'
             assert _get_text(jats, 'body/sec/fig/object-id') == 'fig_0'
             assert _get_text(jats, 'body/sec/fig/label') == 'Figure 1'
+            assert _get_text(jats, 'body/sec/fig/caption/title') == 'Figure 1'
             assert _get_text(jats, 'body/sec/fig/caption/p') == 'Figure 1. This is the figure'
             assert _get_item(jats, 'body/sec/fig/graphic') is not None
             assert _get_text(jats, 'body/sec/p/xref') == '(Figure 1)'
@@ -539,6 +540,7 @@ class TestGrobidJatsXslt(object):
             ))
             assert _get_text(jats, 'body/sec/table-wrap/@id') == 'tab_0'
             assert _get_text(jats, 'body/sec/table-wrap/label') == 'Table 1'
+            assert _get_text(jats, 'body/sec/table-wrap/caption/title') == 'Table 1'
             assert _get_text(jats, 'body/sec/table-wrap/caption/p') == 'Table 1. This is a table'
             assert _get_item(jats, 'body/sec/table-wrap/table') is not None
             assert _get_item(jats, 'body/sec/table-wrap/table/tbody') is not None

--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -112,10 +112,6 @@
     </sec>
   </xsl:template>
 
-  <xsl:template match="tei:head">
-    <title><xsl:value-of select="."/></title>
-  </xsl:template>
-
   <xsl:template match="tei:back">
     <xsl:apply-templates select="tei:div/tei:listBibl"/>
   </xsl:template>
@@ -231,6 +227,10 @@
         </xsl:for-each>
       </given-names>
     </name>
+  </xsl:template>
+
+  <xsl:template match="tei:head">
+    <title><xsl:value-of select="."/></title>
   </xsl:template>
 
   <xsl:template match="tei:title">

--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -103,6 +103,19 @@
 
   <xsl:template match="tei:body">
     <xsl:apply-templates select="tei:div"/>
+    <xsl:if test="tei:figure">
+      <sec id="figures">
+        <title>Figures</title>
+        <xsl:for-each select="tei:figure">
+          <fig>
+            <object-id><xsl:value-of select="@xml:id"/></object-id>
+            <label><xsl:value-of select="tei:head"/></label>
+            <caption><p><xsl:value-of select="tei:figDesc"/></p></caption>
+            <graphic />
+          </fig>
+        </xsl:for-each>
+      </sec>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template match="tei:div">
@@ -227,6 +240,10 @@
         </xsl:for-each>
       </given-names>
     </name>
+  </xsl:template>
+
+  <xsl:template match="tei:figure">
+    <label>Figure 1</label>
   </xsl:template>
 
   <xsl:template match="tei:head">

--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -11,7 +11,9 @@
   <xsl:template match="/">
     <article article-type="research-article">
       <xsl:apply-templates select="tei:TEI/tei:teiHeader"/>
-      <body/>
+      <body>
+        <xsl:apply-templates select="tei:TEI/tei:text/tei:body"/>
+      </body>
       <back>
         <xsl:apply-templates select="tei:TEI/tei:text/tei:back"/>
       </back>
@@ -97,6 +99,25 @@
         </abstract>
       </article-meta>
     </front>
+  </xsl:template>
+
+  <xsl:template match="tei:body">
+    <xsl:apply-templates select="tei:div"/>
+  </xsl:template>
+
+  <xsl:template match="tei:div">
+    <sec>
+      <xsl:apply-templates select="tei:head"/>
+      <xsl:apply-templates select="tei:p"/>
+    </sec>
+  </xsl:template>
+
+  <xsl:template match="tei:head">
+    <title><xsl:value-of select="."/></title>
+  </xsl:template>
+
+  <xsl:template match="tei:p">
+    <title><xsl:value-of select="."/></title>
   </xsl:template>
 
   <xsl:template match="tei:back">

--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -108,6 +108,9 @@
         <title>Figures</title>
         <xsl:for-each select="tei:figure">
           <fig>
+            <xsl:attribute name='id'>
+              <xsl:value-of select="@xml:id"/>
+            </xsl:attribute>
             <object-id><xsl:value-of select="@xml:id"/></object-id>
             <label><xsl:value-of select="tei:head"/></label>
             <caption><p><xsl:value-of select="tei:figDesc"/></p></caption>
@@ -242,8 +245,20 @@
     </name>
   </xsl:template>
 
-  <xsl:template match="tei:figure">
-    <label>Figure 1</label>
+  <xsl:template match="tei:ref">
+    <xsl:choose>
+      <xsl:when test="@type = 'figure'">
+        <xref ref-type="fig">
+          <xsl:attribute name='rid'>
+            <xsl:value-of select="substring-after(@target, '#')"/>
+          </xsl:attribute>
+          <xsl:value-of select="."/>
+        </xref>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="."/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <xsl:template match="tei:head">

--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -127,7 +127,10 @@
       </xsl:attribute>
       <object-id><xsl:value-of select="@xml:id"/></object-id>
       <label><xsl:value-of select="tei:head"/></label>
-      <caption><p><xsl:value-of select="tei:figDesc"/></p></caption>
+      <caption>
+        <title><xsl:value-of select="tei:head"/></title>
+        <p><xsl:value-of select="tei:figDesc"/></p>
+      </caption>
       <graphic />
     </fig>
   </xsl:template>
@@ -138,7 +141,10 @@
         <xsl:value-of select="@xml:id"/>
       </xsl:attribute>
       <label><xsl:value-of select="tei:head"/></label>
-      <caption><p><xsl:value-of select="tei:figDesc"/></p></caption>
+      <caption>
+        <title><xsl:value-of select="tei:head"/></title>
+        <p><xsl:value-of select="tei:figDesc"/></p>
+      </caption>
       <table>
         <tbody>
           <tr>

--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -116,10 +116,6 @@
     <title><xsl:value-of select="."/></title>
   </xsl:template>
 
-  <xsl:template match="tei:p">
-    <title><xsl:value-of select="."/></title>
-  </xsl:template>
-
   <xsl:template match="tei:back">
     <xsl:apply-templates select="tei:div/tei:listBibl"/>
   </xsl:template>

--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -247,6 +247,14 @@
 
   <xsl:template match="tei:ref">
     <xsl:choose>
+      <xsl:when test="@type = 'bibr' and @target">
+        <xref ref-type="bibr">
+          <xsl:attribute name='rid'>
+            <xsl:value-of select="substring-after(@target, '#')"/>
+          </xsl:attribute>
+          <xsl:value-of select="."/>
+        </xref>
+      </xsl:when>
       <xsl:when test="@type = 'figure'">
         <xref ref-type="fig">
           <xsl:attribute name='rid'>

--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -107,18 +107,48 @@
       <sec id="figures">
         <title>Figures</title>
         <xsl:for-each select="tei:figure">
-          <fig>
-            <xsl:attribute name='id'>
-              <xsl:value-of select="@xml:id"/>
-            </xsl:attribute>
-            <object-id><xsl:value-of select="@xml:id"/></object-id>
-            <label><xsl:value-of select="tei:head"/></label>
-            <caption><p><xsl:value-of select="tei:figDesc"/></p></caption>
-            <graphic />
-          </fig>
+          <xsl:choose>
+            <xsl:when test="@type = 'table'">
+              <xsl:call-template name="tei_table"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:call-template name="tei_figure"/>
+            </xsl:otherwise>
+          </xsl:choose>
         </xsl:for-each>
       </sec>
     </xsl:if>
+  </xsl:template>
+
+  <xsl:template name="tei_figure">
+    <fig>
+      <xsl:attribute name='id'>
+        <xsl:value-of select="@xml:id"/>
+      </xsl:attribute>
+      <object-id><xsl:value-of select="@xml:id"/></object-id>
+      <label><xsl:value-of select="tei:head"/></label>
+      <caption><p><xsl:value-of select="tei:figDesc"/></p></caption>
+      <graphic />
+    </fig>
+  </xsl:template>
+
+  <xsl:template name="tei_table">
+    <table-wrap>
+      <xsl:attribute name='id'>
+        <xsl:value-of select="@xml:id"/>
+      </xsl:attribute>
+      <label><xsl:value-of select="tei:head"/></label>
+      <caption><p><xsl:value-of select="tei:figDesc"/></p></caption>
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <xsl:value-of select="tei:table"/>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </table-wrap>
   </xsl:template>
 
   <xsl:template match="tei:div">
@@ -255,8 +285,16 @@
           <xsl:value-of select="."/>
         </xref>
       </xsl:when>
-      <xsl:when test="@type = 'figure'">
+      <xsl:when test="@type = 'figure' and @target">
         <xref ref-type="fig">
+          <xsl:attribute name='rid'>
+            <xsl:value-of select="substring-after(@target, '#')"/>
+          </xsl:attribute>
+          <xsl:value-of select="."/>
+        </xref>
+      </xsl:when>
+      <xsl:when test="@type = 'table' and @target">
+        <xref ref-type="table">
           <xsl:attribute name='rid'>
             <xsl:value-of select="substring-after(@target, '#')"/>
           </xsl:attribute>


### PR DESCRIPTION
The mapping is currently done in XSLT. Python is used for the tests.

/cc @tayowonibi 