### PR TITLE
fix doc to pdf conversion docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,11 @@ RUN useradd -ms /bin/bash sciencebeam
 USER sciencebeam
 ENV HOME=/home/sciencebeam
 
+# set and check UNO_PYTHON_PATH
+ENV UNO_PYTHON_PATH=python3.7
+RUN ${UNO_PYTHON_PATH} -c 'import uno, unohelper' \
+  && echo "UNO_PYTHON_PATH: ${UNO_PYTHON_PATH}"
+
 # labels
 LABEL org.opencontainers.image.source="https://github.com/elifesciences/sciencebeam"
 LABEL org.opencontainers.image.revision="${commit}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ COPY sciencebeam ${PROJECT_HOME}/sciencebeam
 COPY xslt ${PROJECT_HOME}/xslt
 COPY *.cfg *.conf *.sh *.in *.txt *.py ${PROJECT_HOME}/
 
+RUN pip install -e . --no-deps
+
 ARG commit
 ARG version
 COPY docker ./docker

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,12 @@ start:
 	$(DOCKER_COMPOSE) up -d --build grobid sciencebeam
 
 
+start-doc-to-pdf:
+	$(DOCKER_COMPOSE) build sciencebeam
+	$(DOCKER_COMPOSE) run --rm --no-deps -p 8075:8075 sciencebeam \
+		python -m sciencebeam.server --host=0.0.0.0 --port=8075 --pipeline=doc_to_pdf $(ARGS)
+
+
 stop:
 	$(DOCKER_COMPOSE) down
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ dev-install:
 	$(PIP) install -r requirements.prereq.txt
 	$(PIP) install -r requirements.txt
 	$(PIP) install -r requirements.dev.txt
+	$(PIP) install -e . --no-deps
 
 
 dev-venv: venv-create dev-install

--- a/sciencebeam/transformers/office_scripts/__init__.py
+++ b/sciencebeam/transformers/office_scripts/__init__.py
@@ -3,5 +3,11 @@ import pkg_resources
 
 
 def get_office_script_directory():
-    dist = pkg_resources.get_distribution("sciencebeam")
-    return os.path.join(dist.location, 'sciencebeam/transformers/office_scripts')
+    try:
+        # with Apache Beam, __file__ might refer to the original file
+        # rather than where it is installed to
+        dist = pkg_resources.get_distribution("sciencebeam")
+        return os.path.join(dist.location, 'sciencebeam/transformers/office_scripts')
+    except pkg_resources.DistributionNotFound:
+        # fallback to use __file__
+        return os.path.dirname(__file__)

--- a/sciencebeam/transformers/office_scripts/office_utils.py
+++ b/sciencebeam/transformers/office_scripts/office_utils.py
@@ -1,3 +1,4 @@
+import os
 from collections import namedtuple
 
 import subprocess
@@ -7,7 +8,7 @@ Office = namedtuple('Office', ['python'])
 
 
 def find_offices():
-    return [Office(python='python3')]
+    return [Office(python=os.environ.get('UNO_PYTHON_PATH') or 'python3')]
 
 
 def find_pyuno_office():


### PR DESCRIPTION
The doc to pdf conversion failed for the docker image because libreoffice uni is installed to python3.7 (whereas the base python image 3.5)

Add `UNO_PYTHON_PATH` and a check as part of building the image.