### PR TITLE
workaround doc to pdf threading issue

### DIFF
--- a/sciencebeam/pipelines/__init__.py
+++ b/sciencebeam/pipelines/__init__.py
@@ -74,7 +74,7 @@ class RequestsPipelineStep(ABC):
     def __init__(self, api_url: str):
         self._api_url = api_url
 
-    def post_data(self, data: dict, session: requests.Session, **kwargs):
+    def post_data(self, data: dict, session: requests.Session, **kwargs) -> requests.Response:
         LOGGER.debug('session: %s', session)
         response = session.post(
             self._api_url,

--- a/sciencebeam/pipelines/api_pipeline.py
+++ b/sciencebeam/pipelines/api_pipeline.py
@@ -23,7 +23,7 @@ class ApiStep(RequestsPipelineStep):
         )
         return {
             'filename': change_ext(data['filename'], None, '.xml'),
-            'content': response.text,
+            'content': response.content,
             'type': response.headers['Content-Type']
         }
 

--- a/sciencebeam/transformers/doc_converter_wrapper.py
+++ b/sciencebeam/transformers/doc_converter_wrapper.py
@@ -25,12 +25,15 @@ def stream_lines_to_logger(lines, logger, prefix=''):
             logger.info('%s%s', prefix, line)
 
 
+def _send_signal(process: subprocess.Popen, sig):
+    if process.returncode is None:
+        get_logger().info('sending %s signal to process %s', sig, process.pid)
+
+
 def stop_process(process: subprocess.Popen):
-    get_logger().info('sending SIGINT signal to process %s', process.pid)
-    try:
-        process.send_signal(signal.SIGINT)
-    except (AttributeError, OSError):
-        process.terminate()
+    _send_signal(process, signal.SIGINT)
+    timer = Timer(60, lambda: _send_signal(process, signal.SIGKILL))
+    timer.start()
 
 
 def _exec_with_logging(command, logging_prefix, process_timeout=None, daemon=False):

--- a/tests/pipelines/api_pipeline_test.py
+++ b/tests/pipelines/api_pipeline_test.py
@@ -77,7 +77,8 @@ class TestScienceParsePipeline:
 
         args.no_science_parse_xslt = True
 
-        response.text = XML_CONTENT
+        response.text = XML_CONTENT.decode('utf-8')
+        response.content = XML_CONTENT
         response.headers = {'Content-Type': MimeTypes.JATS_XML}
 
         result = _run_pipeline(config, args, PDF_INPUT)


### PR DESCRIPTION
The libreoffice uno bridge doesn't seem to work well with multi-threading. Use a lock for now to only convert one file at a time (from word to pdf).