### PR TITLE
further improve soffice monitoring

### DIFF
--- a/app-defaults.cfg
+++ b/app-defaults.cfg
@@ -9,3 +9,6 @@ contentmine = sciencebeam.pipelines.doc_to_pdf_pipeline, sciencebeam.pipelines.c
 metypeset = sciencebeam.pipelines.doc_to_docx_pipeline, sciencebeam.pipelines.metypeset_pipeline
 sciencebeam_autocut = sciencebeam.pipelines.sciencebeam_autocut_pipeline
 api = sciencebeam.pipelines.api_pipeline
+
+[server]
+max_concurrent_threads = 10

--- a/sciencebeam/config/app_config.py
+++ b/sciencebeam/config/app_config.py
@@ -23,7 +23,6 @@ def get_app_defaults_config_filename():
 
 def parse_environment_variable_overrides(
         env_vars: dict, prefix='SCIENCEBEAM__', section_separator='__'):
-    LOGGER.debug('env_vars: %s', env_vars)
     result = {}
     for key, value in env_vars.items():
         if not key.startswith(prefix):

--- a/tests/server/blueprints/api_test.py
+++ b/tests/server/blueprints/api_test.py
@@ -12,6 +12,7 @@ from werkzeug.exceptions import BadRequest
 import pytest
 
 from sciencebeam.utils.mime_type_constants import MimeTypes
+from sciencebeam.utils.config import dict_to_config
 
 from sciencebeam.pipelines import FieldNames
 
@@ -56,7 +57,7 @@ def _pipeline_runner(create_simple_pipeline_runner_from_config):
 
 @pytest.fixture(name='config')
 def _config():
-    return MagicMock(name='config')
+    return dict_to_config({})
 
 
 @pytest.fixture(name='args')


### PR DESCRIPTION
Now checking the listener port and option to limit number of concurrent request threads.

app config can now in general be overridden using environment variables.

e.g. `SCIENCEBEAM__SERVER__MAX_CONCURRENT_THREADS` would override `max_concurrent_threads` in the section `[server]`
