### PR TITLE
xslt back section support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /venv
 /logs
 /.temp
+/.pytest_cache
 
 .cache
 .models

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ The [ScienceBeam API](doc/API.md) will be available on port _8075_.
 
 The pipeline used by the API is currently is using the simple pipeline format described above. The pipeline can be configured via `app.cfg` (default: `app-defaults.cfg`). The default pipeline uses GROBID.
 
+See [CONFIG.md](docs/CONFIG.md) for more information.
+
 ## Doc to PDF
 
 The default configuration includes a Doc to PDF conversion, as most tools will accept a PDF.

--- a/app-defaults.cfg
+++ b/app-defaults.cfg
@@ -29,3 +29,4 @@ enable_debug = false
 
 output_parameters = false
 acknowledgement_target = ack
+annex_target = body

--- a/app-defaults.cfg
+++ b/app-defaults.cfg
@@ -23,3 +23,9 @@ process_timeout = 300
 max_uptime = 86400
 
 enable_debug = false
+
+
+[xslt_template_parameters]
+
+output_parameters = false
+acknowledgement_target = ack

--- a/app-defaults.cfg
+++ b/app-defaults.cfg
@@ -29,4 +29,4 @@ enable_debug = false
 
 output_parameters = false
 acknowledgement_target = ack
-annex_target = body
+annex_target = back

--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -1,0 +1,19 @@
+# ScienceBeam Config
+
+ScienceBeam can mainly be configured via an optional `app.cfg` and environment variables.
+
+The [app-defaults.cfg](../app-defaults.cfg) file defines the default configuration and also documents some of the available options.
+
+Those options can also be overridden using environment variables following the following naming convention (using double underscores):
+
+`SCIENCEBEAM__<section name>__<parameter name>`.
+
+The environment variable should be all upper case. Section names and parameter names are assumed to be lower case.
+
+Some example configuration options:
+
+| section | parameter name | environment variable name | description
+| --------| -------------- | ------------------------- | -----------
+| pipelines  | default | SCIENCEBEAM__PIPELINES__DEFAULT | the default pipeline, e.g. `grobid` |
+| server  | max_concurrent_threads | SCIENCEBEAM__SERVER__MAX_CONCURRENT_THREADS | maximum of concurrent threads processed by the server |
+| xslt_template_parameters  | acknowledgement_target | SCIENCEBEAM__XSLT_TEMPLATE_PARAMETERS__ACKNOWLEDGEMENT_TARGET | xslt parameter, defining where to output the acknowledgement section (e.g. `ack` or `body`) |

--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -17,3 +17,4 @@ Some example configuration options:
 | pipelines  | default | SCIENCEBEAM__PIPELINES__DEFAULT | the default pipeline, e.g. `grobid` |
 | server  | max_concurrent_threads | SCIENCEBEAM__SERVER__MAX_CONCURRENT_THREADS | maximum of concurrent threads processed by the server |
 | xslt_template_parameters  | acknowledgement_target | SCIENCEBEAM__XSLT_TEMPLATE_PARAMETERS__ACKNOWLEDGEMENT_TARGET | xslt parameter, defining where to output the acknowledgement section (e.g. `ack` or `body`) |
+| xslt_template_parameters  | annex_target | SCIENCEBEAM__XSLT_TEMPLATE_PARAMETERS__ANNEX_TARGET | xslt parameter, defining where to output the annex section (e.g. `back`, `app` or `body`) |

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
 testpaths = tests
-cache_dir = .temp/pytest
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests==2.25.1
 sciencebeam-utils==0.1.4
 six==1.16.0
 tqdm==4.60.0
+typing-extensions==3.10.0.0

--- a/sciencebeam/config/app_config.py
+++ b/sciencebeam/config/app_config.py
@@ -24,6 +24,7 @@ def get_app_defaults_config_filename():
 def parse_environment_variable_overrides(
         env_vars: dict, prefix='SCIENCEBEAM__', section_separator='__'):
     result = {}
+    LOGGER.debug('env_vars: %r', env_vars)
     for key, value in env_vars.items():
         if not key.startswith(prefix):
             continue

--- a/sciencebeam/transformers/xslt.py
+++ b/sciencebeam/transformers/xslt.py
@@ -59,21 +59,21 @@ class xslt_transformer_from_string:
     def __call__(
         self,
         x: Union[bytes, str, T_XSLT_Input],
-        template_arguments: Optional[dict] = None
+        xslt_template_parameters: Optional[dict] = None
     ):
         xslt_input = _to_xslt_input(x)
-        if template_arguments is None:
-            template_arguments = {}
+        if xslt_template_parameters is None:
+            xslt_template_parameters = {}
         LOGGER.debug(
-            'xslt_input: %r (template_arguments=%r)',
-            xslt_input, template_arguments
+            'xslt_input: %r (xslt_template_parameters=%r)',
+            xslt_input, xslt_template_parameters
         )
         return _format_output(
             self._get_transform()(
                 xslt_input,
                 **{
                     key: etree.XSLT.strparam(value)
-                    for key, value in template_arguments.items()
+                    for key, value in xslt_template_parameters.items()
                 }
             ),
             to_string=self.to_string,

--- a/sciencebeam/transformers/xslt.py
+++ b/sciencebeam/transformers/xslt.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union
+from typing import Optional, Union
 
 from lxml import etree
 from lxml.etree import Element, ElementTree
@@ -34,7 +34,12 @@ def xslt_transformer_from_file(xslt_filename, *args, **kwargs):
 
 
 class xslt_transformer_from_string:
-    def __init__(self, xslt_template, to_string=True, pretty_print=False):
+    def __init__(
+        self,
+        xslt_template: str,
+        to_string: bool = True,
+        pretty_print: bool = False
+    ):
         self.xslt_template = xslt_template
         self.to_string = to_string
         self.pretty_print = pretty_print
@@ -45,15 +50,32 @@ class xslt_transformer_from_string:
     def _get_transform(self):
         if self.__transform is None:
             # The transform function cannot be pickled and needs to be loaded lazily
-            transform = etree.XSLT(etree.fromstring(self.xslt_template))
+            transform = etree.XSLT(
+                etree.fromstring(self.xslt_template)
+            )
             self.__transform = transform
         return self.__transform
 
-    def __call__(self, x):
+    def __call__(
+        self,
+        x: Union[bytes, str, T_XSLT_Input],
+        template_arguments: Optional[dict] = None
+    ):
         xslt_input = _to_xslt_input(x)
-        LOGGER.debug('xslt_input: %s', xslt_input)
+        if template_arguments is None:
+            template_arguments = {}
+        LOGGER.debug(
+            'xslt_input: %r (template_arguments=%r)',
+            xslt_input, template_arguments
+        )
         return _format_output(
-            self._get_transform()(xslt_input),
+            self._get_transform()(
+                xslt_input,
+                **{
+                    key: etree.XSLT.strparam(value)
+                    for key, value in template_arguments.items()
+                }
+            ),
             to_string=self.to_string,
             pretty_print=self.pretty_print
         )

--- a/tests/pipelines/grobid_pipeline_test.py
+++ b/tests/pipelines/grobid_pipeline_test.py
@@ -150,7 +150,7 @@ class TestGrobidPipeline:
             PDF_INPUT['filename'], TEI_CONTENT
         )
         result = _run_pipeline(config, args, PDF_INPUT)
-        xslt_transformer.assert_called_with(TEI_CONTENT)
+        xslt_transformer.assert_called_with(TEI_CONTENT, xslt_template_parameters={})
         assert result['content'] == xslt_transformer.return_value
         assert result['type'] == MimeTypes.JATS_XML
 

--- a/tests/transformers/grobid_jats_xslt_test.py
+++ b/tests/transformers/grobid_jats_xslt_test.py
@@ -641,6 +641,26 @@ class TestGrobidJatsXslt:
             assert _get_text(jats, 'body/sec/title') == VALUE_1
             assert _get_text(jats, 'body/sec/p') == VALUE_2
 
+        def test_should_extract_annex_head_and_p_divs_as_body(
+            self, grobid_jats_xslt: T_GrobidJatsXslt
+        ):
+            jats = etree.fromstring(grobid_jats_xslt(
+                _tei(back=E.back(
+                    E.div(
+                        {'type': 'annex'},
+                        E.div(
+                            E.head(VALUE_1),
+                            E.p(VALUE_2)
+                        )
+                    )
+                )),
+                {
+                    'annex_target': 'body'
+                }
+            ))
+            assert _get_text(jats, 'body/sec/title') == VALUE_1
+            assert _get_text(jats, 'body/sec/p') == VALUE_2
+
     class TestReferences:
         def test_should_convert_single_reference(self, grobid_jats_xslt):
             jats = etree.fromstring(grobid_jats_xslt(

--- a/tests/transformers/grobid_jats_xslt_test.py
+++ b/tests/transformers/grobid_jats_xslt_test.py
@@ -615,7 +615,7 @@ class TestGrobidJatsXslt:
                     )
                 )),
                 {
-                    'acknowledgementTarget': 'ack'
+                    'acknowledgement_target': 'ack'
                 }
             ))
             assert _get_text(jats, 'back/ack/sec/title') == VALUE_1
@@ -635,7 +635,7 @@ class TestGrobidJatsXslt:
                     )
                 )),
                 {
-                    'acknowledgementTarget': 'body'
+                    'acknowledgement_target': 'body'
                 }
             ))
             assert _get_text(jats, 'body/sec/title') == VALUE_1

--- a/tests/transformers/grobid_jats_xslt_test.py
+++ b/tests/transformers/grobid_jats_xslt_test.py
@@ -681,6 +681,26 @@ class TestGrobidJatsXslt:
             assert _get_text(jats, 'body/sec/title') == VALUE_1
             assert _get_text(jats, 'body/sec/p') == VALUE_2
 
+        def test_should_extract_annex_head_and_p_divs_as_app_group(
+            self, grobid_jats_xslt: T_GrobidJatsXslt
+        ):
+            jats = etree.fromstring(grobid_jats_xslt(
+                _tei(back=E.back(
+                    E.div(
+                        {'type': 'annex'},
+                        E.div(
+                            E.head(VALUE_1),
+                            E.p(VALUE_2)
+                        )
+                    )
+                )),
+                {
+                    'annex_target': 'app'
+                }
+            ))
+            assert _get_text(jats, 'back/app-group/app/sec/title') == VALUE_1
+            assert _get_text(jats, 'back/app-group/app/sec/p') == VALUE_2
+
     class TestReferences:
         def test_should_convert_single_reference(self, grobid_jats_xslt):
             jats = etree.fromstring(grobid_jats_xslt(

--- a/tests/transformers/grobid_jats_xslt_test.py
+++ b/tests/transformers/grobid_jats_xslt_test.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 import logging
 from typing import List, Optional, Protocol
 

--- a/tests/transformers/grobid_jats_xslt_test.py
+++ b/tests/transformers/grobid_jats_xslt_test.py
@@ -701,6 +701,28 @@ class TestGrobidJatsXslt:
             assert _get_text(jats, 'back/app-group/app/sec/title') == VALUE_1
             assert _get_text(jats, 'back/app-group/app/sec/p') == VALUE_2
 
+        def test_should_extract_annex_figures_as_back_section(
+            self, grobid_jats_xslt: T_GrobidJatsXslt
+        ):
+            jats = etree.fromstring(grobid_jats_xslt(
+                _tei(back=E.back(
+                    E.div(
+                        {'type': 'annex'},
+                        E.figure(
+                            E.head('Figure 1'),
+                            E.label('1'),
+                            E.figDesc('Figure 1. This is the figure')
+                        )
+                    )
+                )),
+                {
+                    'annex_target': 'back'
+                }
+            ))
+            assert _get_text(jats, 'back/sec/fig/label') == 'Figure 1'
+            assert _get_text(jats, 'back/sec/fig/caption/title') == 'Figure 1'
+            assert _get_text(jats, 'back/sec/fig/caption/p') == 'Figure 1. This is the figure'
+
     class TestReferences:
         def test_should_convert_single_reference(self, grobid_jats_xslt):
             jats = etree.fromstring(grobid_jats_xslt(

--- a/tests/transformers/grobid_jats_xslt_test.py
+++ b/tests/transformers/grobid_jats_xslt_test.py
@@ -641,6 +641,26 @@ class TestGrobidJatsXslt:
             assert _get_text(jats, 'body/sec/title') == VALUE_1
             assert _get_text(jats, 'body/sec/p') == VALUE_2
 
+        def test_should_extract_annex_head_and_p_divs_as_back_section(
+            self, grobid_jats_xslt: T_GrobidJatsXslt
+        ):
+            jats = etree.fromstring(grobid_jats_xslt(
+                _tei(back=E.back(
+                    E.div(
+                        {'type': 'annex'},
+                        E.div(
+                            E.head(VALUE_1),
+                            E.p(VALUE_2)
+                        )
+                    )
+                )),
+                {
+                    'annex_target': 'back'
+                }
+            ))
+            assert _get_text(jats, 'back/sec/title') == VALUE_1
+            assert _get_text(jats, 'back/sec/p') == VALUE_2
+
         def test_should_extract_annex_head_and_p_divs_as_body(
             self, grobid_jats_xslt: T_GrobidJatsXslt
         ):

--- a/tests/transformers/grobid_jats_xslt_test.py
+++ b/tests/transformers/grobid_jats_xslt_test.py
@@ -1,6 +1,11 @@
 # pylint: disable=too-many-lines
 import logging
-from typing import List, Optional, Protocol
+from typing import List, Optional
+
+try:
+    from typing import Protocol
+except ImportError:
+    from typing import Generic as Protocol
 
 from six import text_type
 

--- a/tests/transformers/grobid_jats_xslt_test.py
+++ b/tests/transformers/grobid_jats_xslt_test.py
@@ -723,6 +723,123 @@ class TestGrobidJatsXslt:
             assert _get_text(jats, 'back/sec/fig/caption/title') == 'Figure 1'
             assert _get_text(jats, 'back/sec/fig/caption/p') == 'Figure 1. This is the figure'
 
+        def test_should_extract_annex_figures_as_body_section(
+            self, grobid_jats_xslt: T_GrobidJatsXslt
+        ):
+            jats = etree.fromstring(grobid_jats_xslt(
+                _tei(back=E.back(
+                    E.div(
+                        {'type': 'annex'},
+                        E.figure(
+                            E.head('Figure 1'),
+                            E.label('1'),
+                            E.figDesc('Figure 1. This is the figure')
+                        )
+                    )
+                )),
+                {
+                    'annex_target': 'body'
+                }
+            ))
+            assert _get_text(jats, 'body/sec/fig/label') == 'Figure 1'
+            assert _get_text(jats, 'body/sec/fig/caption/title') == 'Figure 1'
+            assert _get_text(jats, 'body/sec/fig/caption/p') == 'Figure 1. This is the figure'
+
+        def test_should_extract_annex_figures_as_app_group(
+            self, grobid_jats_xslt: T_GrobidJatsXslt
+        ):
+            jats = etree.fromstring(grobid_jats_xslt(
+                _tei(back=E.back(
+                    E.div(
+                        {'type': 'annex'},
+                        E.figure(
+                            E.head('Figure 1'),
+                            E.label('1'),
+                            E.figDesc('Figure 1. This is the figure')
+                        )
+                    )
+                )),
+                {
+                    'annex_target': 'app'
+                }
+            ))
+            assert _get_text(jats, 'back/app-group/app/fig/label') == 'Figure 1'
+            assert _get_text(jats, 'back/app-group/app/fig/caption/title') == 'Figure 1'
+            assert _get_text(jats, 'back/app-group/app/fig/caption/p') == (
+                'Figure 1. This is the figure'
+            )
+
+        def test_should_extract_annex_tables_as_back_section(
+            self, grobid_jats_xslt: T_GrobidJatsXslt
+        ):
+            jats = etree.fromstring(grobid_jats_xslt(
+                _tei(back=E.back(
+                    E.div(
+                        {'type': 'annex'},
+                        E.figure(
+                            {'type': 'table'},
+                            E.head('Table 1'),
+                            E.label('1'),
+                            E.figDesc('Table 1. This is the table')
+                        )
+                    )
+                )),
+                {
+                    'annex_target': 'back'
+                }
+            ))
+            assert _get_text(jats, 'back/sec/table-wrap/label') == 'Table 1'
+            assert _get_text(jats, 'back/sec/table-wrap/caption/title') == 'Table 1'
+            assert _get_text(jats, 'back/sec/table-wrap/caption/p') == 'Table 1. This is the table'
+
+        def test_should_extract_annex_tables_as_body_section(
+            self, grobid_jats_xslt: T_GrobidJatsXslt
+        ):
+            jats = etree.fromstring(grobid_jats_xslt(
+                _tei(back=E.back(
+                    E.div(
+                        {'type': 'annex'},
+                        E.figure(
+                            {'type': 'table'},
+                            E.head('Table 1'),
+                            E.label('1'),
+                            E.figDesc('Table 1. This is the table')
+                        )
+                    )
+                )),
+                {
+                    'annex_target': 'body'
+                }
+            ))
+            assert _get_text(jats, 'body/sec/table-wrap/label') == 'Table 1'
+            assert _get_text(jats, 'body/sec/table-wrap/caption/title') == 'Table 1'
+            assert _get_text(jats, 'body/sec/table-wrap/caption/p') == 'Table 1. This is the table'
+
+        def test_should_extract_annex_tables_as_app_group(
+            self, grobid_jats_xslt: T_GrobidJatsXslt
+        ):
+            jats = etree.fromstring(grobid_jats_xslt(
+                _tei(back=E.back(
+                    E.div(
+                        {'type': 'annex'},
+                        E.figure(
+                            {'type': 'table'},
+                            E.head('Table 1'),
+                            E.label('1'),
+                            E.figDesc('Table 1. This is the table')
+                        )
+                    )
+                )),
+                {
+                    'annex_target': 'app'
+                }
+            ))
+            assert _get_text(jats, 'back/app-group/app/table-wrap/label') == 'Table 1'
+            assert _get_text(jats, 'back/app-group/app/table-wrap/caption/title') == 'Table 1'
+            assert _get_text(jats, 'back/app-group/app/table-wrap/caption/p') == (
+                'Table 1. This is the table'
+            )
+
     class TestReferences:
         def test_should_convert_single_reference(self, grobid_jats_xslt):
             jats = etree.fromstring(grobid_jats_xslt(

--- a/tests/transformers/grobid_jats_xslt_test.py
+++ b/tests/transformers/grobid_jats_xslt_test.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 try:
     from typing import Protocol
 except ImportError:
-    from typing import Generic as Protocol
+    from typing_extensions import Protocol
 
 from six import text_type
 

--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -10,7 +10,7 @@
 >
   <xsl:param name="output_parameters" select="'false'"/>
   <xsl:param name="acknowledgement_target" select="'ack'"/>
-  <xsl:param name="annex_target" select="'body'"/>
+  <xsl:param name="annex_target" select="'back'"/>
 
   <xsl:template match="/">
     <article article-type="research-article">
@@ -115,6 +115,10 @@
             <meta-name>xslt-param-acknowledgement_target</meta-name>
             <meta-value><xsl:value-of select="$acknowledgement_target"/></meta-value>
           </custom-meta>
+          <custom-meta>
+            <meta-name>xslt-param-annex_target</meta-name>
+            <meta-value><xsl:value-of select="$annex_target"/></meta-value>
+          </custom-meta>
         </custom-meta-group>
       </xsl:if>
     </article-meta>
@@ -188,6 +192,9 @@
       <ack>
         <xsl:apply-templates select="tei:div[@type='acknowledgement']/tei:div"/>
       </ack>
+    </xsl:if>
+    <xsl:if test="tei:div[@type='annex'] and $annex_target = 'back'">
+      <xsl:apply-templates select="tei:div[@type='annex']/tei:div"/>
     </xsl:if>
     <xsl:apply-templates select="tei:div/tei:listBibl"/>
   </xsl:template>

--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -19,10 +19,10 @@
       </front>
       <body>
         <xsl:apply-templates select="tei:TEI/tei:text/tei:body"/>
-        <xsl:if test="tei:TEI/tei:text/tei:back/tei:div[@type='acknowledgement'] and $acknowledgement_target = 'body'">
+        <xsl:if test="$acknowledgement_target = 'body'">
           <xsl:apply-templates select="tei:TEI/tei:text/tei:back/tei:div[@type='acknowledgement']/tei:div"/>
         </xsl:if>
-        <xsl:if test="tei:TEI/tei:text/tei:back/tei:div[@type='annex'] and $annex_target = 'body'">
+        <xsl:if test="$annex_target = 'body'">
           <xsl:for-each select="tei:TEI/tei:text/tei:back/tei:div[@type='annex']">
             <xsl:apply-templates select="tei:div"/>
             <xsl:if test="tei:figure">
@@ -187,12 +187,14 @@
   </xsl:template>
 
   <xsl:template match="tei:back">
-    <xsl:if test="tei:div[@type='acknowledgement'] and $acknowledgement_target = 'ack'">
-      <ack>
-        <xsl:apply-templates select="tei:div[@type='acknowledgement']/tei:div"/>
-      </ack>
+    <xsl:if test="$acknowledgement_target = 'ack'">
+      <xsl:if test="tei:div[@type='acknowledgement']">
+        <ack>
+          <xsl:apply-templates select="tei:div[@type='acknowledgement']/tei:div"/>
+        </ack>
+      </xsl:if>
     </xsl:if>
-    <xsl:if test="tei:div[@type='annex'] and $annex_target = 'back'">
+    <xsl:if test="$annex_target = 'back'">
       <xsl:for-each select="tei:div[@type='annex']">
         <xsl:apply-templates select="tei:div"/>
         <xsl:if test="tei:figure">
@@ -204,14 +206,16 @@
       </xsl:for-each>
     </xsl:if>
     <xsl:apply-templates select="tei:div/tei:listBibl"/>
-    <xsl:if test="tei:div[@type='annex'] and $annex_target = 'app'">
-      <app-group>
-        <app id="appendix-1">
-          <title>Appendix 1</title>
-          <xsl:apply-templates select="tei:div[@type='annex']/tei:div"/>
-          <xsl:apply-templates select="tei:div[@type='annex']/tei:figure"/>
-        </app>
-      </app-group>
+    <xsl:if test="$annex_target = 'app'">
+      <xsl:if test="tei:div[@type='annex']">
+        <app-group>
+          <app id="appendix-1">
+            <title>Appendix 1</title>
+            <xsl:apply-templates select="tei:div[@type='annex']/tei:div"/>
+            <xsl:apply-templates select="tei:div[@type='annex']/tei:figure"/>
+          </app>
+        </app-group>
+      </xsl:if>
     </xsl:if>
   </xsl:template>
 

--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -197,6 +197,14 @@
       <xsl:apply-templates select="tei:div[@type='annex']/tei:div"/>
     </xsl:if>
     <xsl:apply-templates select="tei:div/tei:listBibl"/>
+    <xsl:if test="tei:div[@type='annex'] and $annex_target = 'app'">
+      <app-group>
+        <app id="appendix-1">
+          <title>Appendix 1</title>
+          <xsl:apply-templates select="tei:div[@type='annex']/tei:div"/>
+        </app>
+      </app-group>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template match="tei:listBibl">

--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -10,6 +10,7 @@
 >
   <xsl:param name="output_parameters" select="'false'"/>
   <xsl:param name="acknowledgement_target" select="'ack'"/>
+  <xsl:param name="annex_target" select="'body'"/>
 
   <xsl:template match="/">
     <article article-type="research-article">
@@ -20,6 +21,9 @@
         <xsl:apply-templates select="tei:TEI/tei:text/tei:body"/>
         <xsl:if test="tei:TEI/tei:text/tei:back/tei:div[@type='acknowledgement'] and $acknowledgement_target = 'body'">
           <xsl:apply-templates select="tei:TEI/tei:text/tei:back/tei:div[@type='acknowledgement']/tei:div"/>
+        </xsl:if>
+        <xsl:if test="tei:TEI/tei:text/tei:back/tei:div[@type='annex'] and $annex_target = 'body'">
+          <xsl:apply-templates select="tei:TEI/tei:text/tei:back/tei:div[@type='annex']/tei:div"/>
         </xsl:if>
       </body>
       <back>

--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -23,7 +23,15 @@
           <xsl:apply-templates select="tei:TEI/tei:text/tei:back/tei:div[@type='acknowledgement']/tei:div"/>
         </xsl:if>
         <xsl:if test="tei:TEI/tei:text/tei:back/tei:div[@type='annex'] and $annex_target = 'body'">
-          <xsl:apply-templates select="tei:TEI/tei:text/tei:back/tei:div[@type='annex']/tei:div"/>
+          <xsl:for-each select="tei:TEI/tei:text/tei:back/tei:div[@type='annex']">
+            <xsl:apply-templates select="tei:div"/>
+            <xsl:if test="tei:figure">
+              <sec id="annex_figures">
+                <title>Annex Figures</title>
+                <xsl:apply-templates select="tei:figure"/>
+              </sec>
+            </xsl:if>
+          </xsl:for-each>
         </xsl:if>
       </body>
       <back>
@@ -126,28 +134,15 @@
 
   <xsl:template match="tei:body">
     <xsl:apply-templates select="tei:div"/>
-    <xsl:call-template name="tei_figures_section"/>
-  </xsl:template>
-
-  <xsl:template name="tei_figures_section">
     <xsl:if test="tei:figure">
       <sec id="figures">
         <title>Figures</title>
-        <xsl:for-each select="tei:figure">
-          <xsl:choose>
-            <xsl:when test="@type = 'table'">
-              <xsl:call-template name="tei_table"/>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:call-template name="tei_figure"/>
-            </xsl:otherwise>
-          </xsl:choose>
-        </xsl:for-each>
+        <xsl:apply-templates select="tei:figure"/>
       </sec>
     </xsl:if>
   </xsl:template>
 
-  <xsl:template name="tei_figure">
+  <xsl:template match="tei:figure[not(@type='table')]">
     <fig>
       <xsl:attribute name='id'>
         <xsl:value-of select="@xml:id"/>
@@ -162,7 +157,7 @@
     </fig>
   </xsl:template>
 
-  <xsl:template name="tei_table">
+  <xsl:template match="tei:figure[@type='table']">
     <table-wrap>
       <xsl:attribute name='id'>
         <xsl:value-of select="@xml:id"/>
@@ -200,7 +195,12 @@
     <xsl:if test="tei:div[@type='annex'] and $annex_target = 'back'">
       <xsl:for-each select="tei:div[@type='annex']">
         <xsl:apply-templates select="tei:div"/>
-        <xsl:call-template name="tei_figures_section"/>
+        <xsl:if test="tei:figure">
+          <sec id="annex_figures">
+            <title>Annex Figures</title>
+            <xsl:apply-templates select="tei:figure"/>
+          </sec>
+        </xsl:if>
       </xsl:for-each>
     </xsl:if>
     <xsl:apply-templates select="tei:div/tei:listBibl"/>
@@ -209,6 +209,7 @@
         <app id="appendix-1">
           <title>Appendix 1</title>
           <xsl:apply-templates select="tei:div[@type='annex']/tei:div"/>
+          <xsl:apply-templates select="tei:div[@type='annex']/tei:figure"/>
         </app>
       </app-group>
     </xsl:if>

--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -12,9 +12,20 @@
 
   <xsl:template match="/">
     <article article-type="research-article">
-      <xsl:apply-templates select="tei:TEI/tei:teiHeader"/>
+      <front>
+        <custom-meta-group>
+          <custom-meta>
+            <meta-name>xslt-param-acknowledgementTarget</meta-name>
+            <meta-value><xsl:value-of select="$acknowledgementTarget"/></meta-value>
+          </custom-meta>
+        </custom-meta-group>
+        <xsl:apply-templates select="tei:TEI/tei:teiHeader"/>
+      </front>
       <body>
         <xsl:apply-templates select="tei:TEI/tei:text/tei:body"/>
+        <xsl:if test="tei:TEI/tei:text/tei:back/tei:div[@type='acknowledgement'] and $acknowledgementTarget = 'body'">
+          <xsl:apply-templates select="tei:TEI/tei:text/tei:back/tei:div[@type='acknowledgement']/tei:div"/>
+        </xsl:if>
       </body>
       <back>
         <xsl:apply-templates select="tei:TEI/tei:text/tei:back"/>
@@ -23,84 +34,82 @@
   </xsl:template>
 
   <xsl:template match="tei:teiHeader">
-    <front>
-      <xsl:if test="tei:fileDesc/tei:sourceDesc/tei:biblStruct/tei:monogr/tei:title">
-        <journal-meta>
-          <journal-title-group>
-            <journal-title>
-              <xsl:value-of select="tei:fileDesc/tei:sourceDesc/tei:biblStruct/tei:monogr/tei:title"/>
-            </journal-title>
-          </journal-title-group>
-        </journal-meta>
-      </xsl:if>
+    <xsl:if test="tei:fileDesc/tei:sourceDesc/tei:biblStruct/tei:monogr/tei:title">
+      <journal-meta>
+        <journal-title-group>
+          <journal-title>
+            <xsl:value-of select="tei:fileDesc/tei:sourceDesc/tei:biblStruct/tei:monogr/tei:title"/>
+          </journal-title>
+        </journal-title-group>
+      </journal-meta>
+    </xsl:if>
 
-      <article-meta>
-        <title-group>
-          <article-title>
-            <xsl:apply-templates select="tei:fileDesc/tei:titleStmt/tei:title"/>
-          </article-title>
-        </title-group>
+    <article-meta>
+      <title-group>
+        <article-title>
+          <xsl:apply-templates select="tei:fileDesc/tei:titleStmt/tei:title"/>
+        </article-title>
+      </title-group>
 
-        <contrib-group content-type="author">
-          <xsl:for-each select="tei:fileDesc/tei:sourceDesc/tei:biblStruct/tei:analytic/tei:author">
-            <contrib contrib-type="person">
-              <xsl:apply-templates select="tei:persName"/>
+      <contrib-group content-type="author">
+        <xsl:for-each select="tei:fileDesc/tei:sourceDesc/tei:biblStruct/tei:analytic/tei:author">
+          <contrib contrib-type="person">
+            <xsl:apply-templates select="tei:persName"/>
 
-              <xsl:if test="tei:email">
-                <email>
-                  <xsl:value-of select="tei:email"/>
-                </email>
-              </xsl:if>
+            <xsl:if test="tei:email">
+              <email>
+                <xsl:value-of select="tei:email"/>
+              </email>
+            </xsl:if>
 
-              <xsl:if test="tei:affiliation">
-                <xref ref-type="aff">
-                  <xsl:attribute name='rid'>
-                    <xsl:value-of select="tei:affiliation/@key"/>
-                  </xsl:attribute>
-                </xref>
-              </xsl:if>
-            </contrib>
-          </xsl:for-each>
-        </contrib-group>
-
-        <xsl:for-each select="tei:fileDesc/tei:sourceDesc/tei:biblStruct/tei:analytic/tei:author/tei:affiliation">
-          <aff>
-            <xsl:attribute name='id'>
-              <xsl:value-of select="@key"/>
-            </xsl:attribute>
-            <xsl:if test="tei:orgName[@type='institution']">
-              <institution content-type="orgname">
-                <xsl:value-of select="tei:orgName[@type='institution']"/>
-              </institution>
+            <xsl:if test="tei:affiliation">
+              <xref ref-type="aff">
+                <xsl:attribute name='rid'>
+                  <xsl:value-of select="tei:affiliation/@key"/>
+                </xsl:attribute>
+              </xref>
             </xsl:if>
-            <xsl:if test="tei:orgName[@type='department']">
-              <institution content-type="orgdiv1">
-                <xsl:value-of select="tei:orgName[@type='department']"/>
-              </institution>
-            </xsl:if>
-            <xsl:if test="tei:orgName[@type='laboratory']">
-              <institution content-type="orgdiv2">
-                <xsl:value-of select="tei:orgName[@type='laboratory']"/>
-              </institution>
-            </xsl:if>
-            <xsl:if test="tei:address/tei:settlement">
-              <city>
-                <xsl:value-of select="tei:address/tei:settlement"/>
-              </city>
-            </xsl:if>
-            <xsl:if test="tei:address/tei:country">
-              <country>
-                <xsl:value-of select="tei:address/tei:country"/>
-              </country>
-            </xsl:if>
-          </aff>
+          </contrib>
         </xsl:for-each>
+      </contrib-group>
 
-        <abstract>
-          <xsl:apply-templates select="tei:profileDesc/tei:abstract"/>
-        </abstract>
-      </article-meta>
-    </front>
+      <xsl:for-each select="tei:fileDesc/tei:sourceDesc/tei:biblStruct/tei:analytic/tei:author/tei:affiliation">
+        <aff>
+          <xsl:attribute name='id'>
+            <xsl:value-of select="@key"/>
+          </xsl:attribute>
+          <xsl:if test="tei:orgName[@type='institution']">
+            <institution content-type="orgname">
+              <xsl:value-of select="tei:orgName[@type='institution']"/>
+            </institution>
+          </xsl:if>
+          <xsl:if test="tei:orgName[@type='department']">
+            <institution content-type="orgdiv1">
+              <xsl:value-of select="tei:orgName[@type='department']"/>
+            </institution>
+          </xsl:if>
+          <xsl:if test="tei:orgName[@type='laboratory']">
+            <institution content-type="orgdiv2">
+              <xsl:value-of select="tei:orgName[@type='laboratory']"/>
+            </institution>
+          </xsl:if>
+          <xsl:if test="tei:address/tei:settlement">
+            <city>
+              <xsl:value-of select="tei:address/tei:settlement"/>
+            </city>
+          </xsl:if>
+          <xsl:if test="tei:address/tei:country">
+            <country>
+              <xsl:value-of select="tei:address/tei:country"/>
+            </country>
+          </xsl:if>
+        </aff>
+      </xsl:for-each>
+
+      <abstract>
+        <xsl:apply-templates select="tei:profileDesc/tei:abstract"/>
+      </abstract>
+    </article-meta>
   </xsl:template>
 
   <xsl:template match="tei:body">

--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -126,6 +126,10 @@
 
   <xsl:template match="tei:body">
     <xsl:apply-templates select="tei:div"/>
+    <xsl:call-template name="tei_figures_section"/>
+  </xsl:template>
+
+  <xsl:template name="tei_figures_section">
     <xsl:if test="tei:figure">
       <sec id="figures">
         <title>Figures</title>
@@ -194,7 +198,10 @@
       </ack>
     </xsl:if>
     <xsl:if test="tei:div[@type='annex'] and $annex_target = 'back'">
-      <xsl:apply-templates select="tei:div[@type='annex']/tei:div"/>
+      <xsl:for-each select="tei:div[@type='annex']">
+        <xsl:apply-templates select="tei:div"/>
+        <xsl:call-template name="tei_figures_section"/>
+      </xsl:for-each>
     </xsl:if>
     <xsl:apply-templates select="tei:div/tei:listBibl"/>
     <xsl:if test="tei:div[@type='annex'] and $annex_target = 'app'">

--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -8,6 +8,8 @@
   exclude-result-prefixes="xlink xs mml tei"
   version="1.0"
 >
+  <xsl:param name="acknowledgementTarget" select="'ack'"/>
+
   <xsl:template match="/">
     <article article-type="research-article">
       <xsl:apply-templates select="tei:TEI/tei:teiHeader"/>
@@ -165,6 +167,11 @@
   </xsl:template>
 
   <xsl:template match="tei:back">
+    <xsl:if test="tei:div[@type='acknowledgement'] and $acknowledgementTarget = 'ack'">
+      <ack>
+        <xsl:apply-templates select="tei:div[@type='acknowledgement']/tei:div"/>
+      </ack>
+    </xsl:if>
     <xsl:apply-templates select="tei:div/tei:listBibl"/>
   </xsl:template>
 

--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -8,22 +8,17 @@
   exclude-result-prefixes="xlink xs mml tei"
   version="1.0"
 >
-  <xsl:param name="acknowledgementTarget" select="'ack'"/>
+  <xsl:param name="output_parameters" select="'false'"/>
+  <xsl:param name="acknowledgement_target" select="'ack'"/>
 
   <xsl:template match="/">
     <article article-type="research-article">
       <front>
-        <custom-meta-group>
-          <custom-meta>
-            <meta-name>xslt-param-acknowledgementTarget</meta-name>
-            <meta-value><xsl:value-of select="$acknowledgementTarget"/></meta-value>
-          </custom-meta>
-        </custom-meta-group>
         <xsl:apply-templates select="tei:TEI/tei:teiHeader"/>
       </front>
       <body>
         <xsl:apply-templates select="tei:TEI/tei:text/tei:body"/>
-        <xsl:if test="tei:TEI/tei:text/tei:back/tei:div[@type='acknowledgement'] and $acknowledgementTarget = 'body'">
+        <xsl:if test="tei:TEI/tei:text/tei:back/tei:div[@type='acknowledgement'] and $acknowledgement_target = 'body'">
           <xsl:apply-templates select="tei:TEI/tei:text/tei:back/tei:div[@type='acknowledgement']/tei:div"/>
         </xsl:if>
       </body>
@@ -109,6 +104,15 @@
       <abstract>
         <xsl:apply-templates select="tei:profileDesc/tei:abstract"/>
       </abstract>
+
+      <xsl:if test="$output_parameters = 'true'">
+        <custom-meta-group>
+          <custom-meta>
+            <meta-name>xslt-param-acknowledgement_target</meta-name>
+            <meta-value><xsl:value-of select="$acknowledgement_target"/></meta-value>
+          </custom-meta>
+        </custom-meta-group>
+      </xsl:if>
     </article-meta>
   </xsl:template>
 
@@ -176,7 +180,7 @@
   </xsl:template>
 
   <xsl:template match="tei:back">
-    <xsl:if test="tei:div[@type='acknowledgement'] and $acknowledgementTarget = 'ack'">
+    <xsl:if test="tei:div[@type='acknowledgement'] and $acknowledgement_target = 'ack'">
       <ack>
         <xsl:apply-templates select="tei:div[@type='acknowledgement']/tei:div"/>
       </ack>


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/144

This adds back section support.

The XSLT stylesheet is configurable and allows the following options:

`acknowledgement_target`: `back` (default) or `body`
`annex_target`: `back` (default), `app` or `body`

If `app` is chosen, a separate `app-group` is created.

`annex` here includes regular sections, figures and tables.