### PR TITLE
added moved note to xslt

### DIFF
--- a/xslt/grobid-jats.xsl
+++ b/xslt/grobid-jats.xsl
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Note: this XSLT has been moved and updated:
+  https://github.com/elifesciences/sciencebeam-parser/blob/develop/sciencebeam_parser/resources/xslt/tei-to-jats.xsl
+-->
 <xsl:stylesheet 
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
   xmlns:xs="http://www.w3.org/2001/XMLSchema" 


### PR DESCRIPTION
Related to https://github.com/elifesciences/sciencebeam-issues/issues/212

Added a note that the XSLT has now been moved and updated:
https://github.com/elifesciences/sciencebeam-parser/blob/develop/sciencebeam_parser/resources/xslt/tei-to-jats.xsl
