### PR TITLE
Upgrade sciencebeam-judge to 0.0.25; add edit_sim scoring method

### DIFF
--- a/benchmarks/eval.yml
+++ b/benchmarks/eval.yml
@@ -46,10 +46,11 @@ scoring:
   #                  (appropriate for ordered fields where predicted count may differ)
   default_methods:
     - levenshtein
+    - edit_sim
   default_type: string
   per_field:
     title:
-      methods: [exact, levenshtein]
+      methods: [exact, levenshtein, edit_sim]
     author_full_names:
       type: ulist
     affiliation_text:

--- a/benchmarks/eval.yml
+++ b/benchmarks/eval.yml
@@ -46,11 +46,12 @@ scoring:
   #                  (appropriate for ordered fields where predicted count may differ)
   default_methods:
     - levenshtein
-    - edit_sim
   default_type: string
   per_field:
     title:
       methods: [exact, levenshtein, edit_sim]
+    abstract:
+      methods: [levenshtein, edit_sim]
     author_full_names:
       type: ulist
     affiliation_text:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "lxml>=6.0.2",
     "pdf2image==1.16.0",
     "pyyaml>=6.0.3",
-    "sciencebeam-judge==0.0.24",
+    "sciencebeam-judge==0.0.25",
 ]
 
 [project.optional-dependencies]
@@ -32,7 +32,7 @@ benchmark = [
     "huggingface-hub>=0.30",
     "numpy>=1.26",
     "pyarrow>=18",
-    "sciencebeam-judge>=0.0.24",
+    "sciencebeam-judge>=0.0.25",
 ]
 dev = [
     "flake8>=4.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -3427,7 +3427,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/f4/48/1fd270b9276de6fb3
 
 [[package]]
 name = "sciencebeam-judge"
-version = "0.0.24"
+version = "0.0.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "configparser" },
@@ -3443,9 +3443,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/2b/dad2ce52d3e8ed3fec73bbb5115f09cb22dca40e300c160c6ecef7128dd2/sciencebeam_judge-0.0.24.tar.gz", hash = "sha256:e5dad4e157389a38530257af852b495dea490d6d5de824ff81a9b50dffb2d664", size = 78529, upload-time = "2026-05-21T16:29:33.853Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/ed/cd58351a63fa923a8200bf98194562bdbc3360ccf0a20b6f16746e87f96f/sciencebeam_judge-0.0.25.tar.gz", hash = "sha256:f98a9e056a58d275d1bcfc3978b0b495979fa2dc0faed0b6ad94f839e40574e5", size = 81073, upload-time = "2026-05-22T10:26:35.67Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/26/d53ba38caef2f5829927bd19cb84a4996084d136dfff1775f2c00f8a4b0b/sciencebeam_judge-0.0.24-py3-none-any.whl", hash = "sha256:e2a2b66f1339297bb1f16fa162d6e4062fe4170ff3e48ff17ce4dabb1945eb0f", size = 105087, upload-time = "2026-05-21T16:29:32.487Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f4/ae230d1e41f7c5494dd40a6e4cba3a4b78cc37821f4da806e6fb0d12926f/sciencebeam_judge-0.0.25-py3-none-any.whl", hash = "sha256:fd90bc3237b42ae7df719c1401cdfb16ec8bd3258af66908fb9d0bb3fdce7532", size = 107716, upload-time = "2026-05-22T10:26:34.556Z" },
 ]
 
 [[package]]
@@ -3459,6 +3459,7 @@ dependencies = [
     { name = "lxml" },
     { name = "pdf2image" },
     { name = "pyyaml" },
+    { name = "sciencebeam-judge" },
 ]
 
 [package.optional-dependencies]
@@ -3510,6 +3511,7 @@ requires-dist = [
     { name = "lxml", specifier = ">=6.0.2" },
     { name = "pdf2image", specifier = "==1.16.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "sciencebeam-judge", specifier = "==0.0.25" },
     { name = "sciencebeam-trainer-delft", extras = ["delft"], marker = "extra == 'delft'", specifier = ">=0.0.38" },
     { name = "torch", marker = "extra == 'cpu'", specifier = ">=2.5.1", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchvision", marker = "extra == 'cpu'", specifier = ">=0.20.1", index = "https://download.pytorch.org/whl/cpu" },
@@ -3522,7 +3524,7 @@ benchmark = [
     { name = "huggingface-hub", specifier = ">=0.30" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "pyarrow", specifier = ">=18" },
-    { name = "sciencebeam-judge", specifier = ">=0.0.24" },
+    { name = "sciencebeam-judge", specifier = ">=0.0.25" },
 ]
 dev = [
     { name = "flake8", specifier = ">=4.0.1" },


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/75

edit_sim reports mean normalised Levenshtein similarity directly as
P = R = F1 (a continuous metric), rather than the threshold-based
levenshtein F1 which measures the fraction of comparisons exceeding
0.8 similarity. Added to default_methods so all string-type fields
gain the metric automatically; list-typed fields silently skip it
pending upstream support.
