### PR TITLE
Add local benchmark runner with GROBID baseline comparison

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,16 @@ dev-benchmark-compare:
 dev-benchmark: dev-benchmark-predict dev-benchmark-score
 
 
+dev-benchmark-with-baselines:
+	$(PYTHON) -m benchmarks.run_local \
+		--config $(BENCHMARK_CONFIG) \
+		--mode $(BENCHMARK_MODE) \
+		--split $(BENCHMARK_SPLIT) \
+		--runs benchmarks/runs \
+		--parser-url $(BENCHMARK_PARSER_URL) \
+		$(ARGS)
+
+
 docker-buildx-bake-build-all:
 	docker buildx bake \
 		--file docker-bake.hcl \

--- a/benchmarks/run_local.py
+++ b/benchmarks/run_local.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional, Tuple, List
+
+import httpx
+import yaml
+
+from benchmarks.predict import run_predict
+from benchmarks.report import run_compare
+from benchmarks.score import run_score
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _tool_docker_config(tool: str, version: str) -> dict:
+    if tool == "grobid":
+        return {
+            "image": f"grobid/grobid:{version}",
+            "port": "8070:8070",
+            "url": "http://localhost:8070",
+            "health_path": "/api/isalive",
+        }
+    return {
+        "image": f"ghcr.io/elifepathways/sciencebeam-parser:{version}",
+        "port": "8080:8070",
+        "url": "http://localhost:8080",
+        "health_path": "/",
+    }
+
+
+def _count_predictions(run_dir: Path) -> int:
+    pred_dir = run_dir / "predictions"
+    if not pred_dir.exists():
+        return 0
+    return sum(1 for _ in pred_dir.rglob("*.tei.xml"))
+
+
+def _expected_count(config: dict, mode: str) -> int:
+    return sum(config.get("sampling", {}).get(mode, {}).values())
+
+
+def _wait_healthy(url: str, health_path: str, retries: int = 60, interval: int = 5) -> None:
+    for i in range(retries):
+        try:
+            r = httpx.get(f"{url}{health_path}", timeout=5)
+            if r.is_success:
+                LOGGER.info("Service ready at %s", url)
+                return
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+        if i < retries - 1:
+            time.sleep(interval)
+    raise RuntimeError(
+        f"Service at {url}{health_path} never became healthy after {retries * interval}s"
+    )
+
+
+def _docker_start(name: str, image: str, port: str) -> None:
+    LOGGER.info("Starting container %s (%s)", name, image)
+    subprocess.run(["docker", "run", "-d", "--name", name, "-p", port, image], check=True)
+
+
+def _docker_stop(name: str) -> None:
+    subprocess.run(["docker", "stop", name], check=False, capture_output=True)
+    subprocess.run(["docker", "rm", name], check=False, capture_output=True)
+
+
+def _run_baseline(
+    config: dict,
+    mode: str,
+    split: str,
+    data_dir: Path,
+    runs_dir: Path,
+    tool: str,
+    version: str,
+    expected: int,
+) -> Optional[Tuple[str, Path]]:
+    run_dir = runs_dir / "baselines" / tool / version / split
+    existing = _count_predictions(run_dir)
+    LOGGER.info("=== Baseline %s/%s: %d/%d predictions ===", tool, version, existing, expected)
+
+    if existing < expected:
+        dcfg = _tool_docker_config(tool, version)
+        container = f"run-local-{tool}"
+        _docker_stop(container)
+        _docker_start(container, dcfg["image"], dcfg["port"])
+        try:
+            _wait_healthy(dcfg["url"], dcfg["health_path"])
+            run_predict(
+                config, mode, split, data_dir, run_dir,
+                dcfg["url"], f"{tool}:{version}", None,
+            )
+        finally:
+            _docker_stop(container)
+    else:
+        LOGGER.info("Predictions already present, skipping predict")
+
+    run_score(config, run_dir, data_dir, out_path=None, split_override=split)
+
+    summary_path = run_dir / "summary.json"
+    return (f"{tool} {version}", summary_path) if summary_path.exists() else None
+
+
+def run_local(
+    config: dict,
+    mode: str,
+    split: str,
+    data_dir: Path,
+    runs_dir: Path,
+    parser_url: Optional[str],
+    parser_image: Optional[str],
+    baseline_only: bool,
+) -> None:
+    expected = _expected_count(config, mode)
+    labeled_paths: List[Tuple[str, Path]] = []
+
+    for baseline in config.get("baselines", []):
+        entry = _run_baseline(
+            config, mode, split, data_dir, runs_dir,
+            baseline["tool"], baseline["version"], expected,
+        )
+        if entry:
+            labeled_paths.append(entry)
+
+    if baseline_only:
+        return
+
+    if parser_url is None:
+        LOGGER.warning("No --parser-url given; skipping primary predict and report")
+        return
+
+    primary_run_dir = runs_dir / split
+    run_predict(config, mode, split, data_dir, primary_run_dir, parser_url, parser_image, None)
+    run_score(config, primary_run_dir, data_dir, out_path=None, split_override=split)
+
+    primary_label = parser_image or "local"
+    labeled_paths.append((primary_label, primary_run_dir / "summary.json"))
+
+    if len(labeled_paths) >= 2:
+        report_path = primary_run_dir / "comparison.md"
+        run_compare(labeled_paths, report_path)
+    else:
+        LOGGER.info("Only one summary available; skipping comparison report")
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Run benchmark locally with baseline comparison"
+    )
+    parser.add_argument("--config", default="benchmarks/eval.yml")
+    parser.add_argument("--mode", choices=["smoke", "full"], default="smoke")
+    parser.add_argument("--split", default="train", help="Dataset split (default: train)")
+    parser.add_argument("--data", default="benchmarks/data")
+    parser.add_argument(
+        "--runs", default="benchmarks/runs", help="Base directory for run outputs"
+    )
+    parser.add_argument(
+        "--parser-url", default=None,
+        help="Primary parser URL (e.g. http://localhost:8080)",
+    )
+    parser.add_argument(
+        "--parser-image", default=None, help="Primary parser image tag (provenance label)"
+    )
+    parser.add_argument(
+        "--baseline-only", action="store_true",
+        help="Only generate and score baselines; skip primary parser",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    with open(args.config, encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    run_local(
+        config=config,
+        mode=args.mode,
+        split=args.split,
+        data_dir=Path(args.data),
+        runs_dir=Path(args.runs),
+        parser_url=args.parser_url,
+        parser_image=args.parser_image,
+        baseline_only=args.baseline_only,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/tests/run_local_test.py
+++ b/benchmarks/tests/run_local_test.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from benchmarks.run_local import (
+    _count_predictions,
+    _expected_count,
+    _tool_docker_config,
+    run_local,
+)
+
+_CONFIG = {
+    "baselines": [{"tool": "grobid", "version": "0.9.0-crf"}],
+    "sampling": {"smoke": {"biorxiv": 10}},
+    "dataset": {
+        "splits": {
+            "train": {"biorxiv": {}},
+            "validation": {"biorxiv": {}},
+        }
+    },
+    "fields": ["title"],
+    "scoring": {"default_methods": ["levenshtein"], "default_type": "string", "per_field": {}},
+}
+
+
+class TestCountPredictions:
+    def test_returns_zero_when_predictions_dir_absent(self, tmp_path: Path):
+        assert _count_predictions(tmp_path) == 0
+
+    def test_counts_tei_xml_files_recursively(self, tmp_path: Path):
+        pred_dir = tmp_path / "predictions" / "biorxiv"
+        pred_dir.mkdir(parents=True)
+        (pred_dir / "doc1.tei.xml").write_text("")
+        (pred_dir / "doc2.tei.xml").write_text("")
+        assert _count_predictions(tmp_path) == 2
+
+    def test_ignores_non_tei_xml_files(self, tmp_path: Path):
+        pred_dir = tmp_path / "predictions"
+        pred_dir.mkdir()
+        (pred_dir / "manifest.jsonl").write_text("")
+        (pred_dir / "doc1.tei.xml").write_text("")
+        assert _count_predictions(tmp_path) == 1
+
+
+class TestExpectedCount:
+    def test_sums_corpora_for_mode(self):
+        config = {"sampling": {"smoke": {"biorxiv": 10, "pmc": 5}}}
+        assert _expected_count(config, "smoke") == 15
+
+    def test_returns_zero_for_missing_mode(self):
+        config = {"sampling": {"smoke": {"biorxiv": 10}}}
+        assert _expected_count(config, "full") == 0
+
+
+class TestToolDockerConfig:
+    def test_grobid_uses_correct_image_and_port(self):
+        cfg = _tool_docker_config("grobid", "0.9.0-crf")
+        assert cfg["image"] == "grobid/grobid:0.9.0-crf"
+        assert cfg["port"] == "8070:8070"
+        assert cfg["url"] == "http://localhost:8070"
+        assert cfg["health_path"] == "/api/isalive"
+
+    def test_sciencebeam_parser_uses_ghcr_image(self):
+        cfg = _tool_docker_config("sciencebeam-parser", "1.2.3")
+        assert cfg["image"] == "ghcr.io/elifepathways/sciencebeam-parser:1.2.3"
+        assert cfg["port"] == "8080:8070"
+
+
+class TestRunLocal:
+    def _make_summary(self, run_dir: Path) -> None:
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "summary.json").write_text(json.dumps({
+            "fields": ["title"],
+            "field_measures": {"title": ["levenshtein"]},
+            "field_scoring_types": {"title": "string"},
+            "corpora": {},
+        }))
+
+    @patch("benchmarks.run_local._docker_stop")
+    @patch("benchmarks.run_local._docker_start")
+    @patch("benchmarks.run_local._wait_healthy")
+    @patch("benchmarks.run_local.run_score")
+    @patch("benchmarks.run_local.run_predict")
+    def test_generates_baseline_predictions_when_none_exist(
+        self, mock_predict, mock_score, _mock_wait, mock_start, _mock_stop, tmp_path: Path
+    ):
+        runs_dir = tmp_path / "runs"
+
+        def fake_score(_config, run_dir, _data_dir, **_kwargs):
+            self._make_summary(run_dir)
+
+        mock_score.side_effect = fake_score
+
+        run_local(_CONFIG, "smoke", "train", tmp_path / "data", runs_dir,
+                  parser_url=None, parser_image=None, baseline_only=True)
+
+        mock_start.assert_called_once()
+        mock_predict.assert_called_once()
+
+    @patch("benchmarks.run_local._docker_stop")
+    @patch("benchmarks.run_local._docker_start")
+    @patch("benchmarks.run_local._wait_healthy")
+    @patch("benchmarks.run_local.run_score")
+    @patch("benchmarks.run_local.run_predict")
+    def test_skips_docker_when_predictions_already_present(
+        self, mock_predict, mock_score, _mock_wait, mock_start, _mock_stop, tmp_path: Path
+    ):
+        runs_dir = tmp_path / "runs"
+        pred_dir = (
+            runs_dir / "baselines" / "grobid" / "0.9.0-crf" / "train" / "predictions" / "biorxiv"
+        )
+        pred_dir.mkdir(parents=True)
+        for i in range(10):
+            (pred_dir / f"doc{i}.tei.xml").write_text("")
+
+        def fake_score(_config, run_dir, _data_dir, **_kwargs):
+            self._make_summary(run_dir)
+
+        mock_score.side_effect = fake_score
+
+        run_local(_CONFIG, "smoke", "train", tmp_path / "data", runs_dir,
+                  parser_url=None, parser_image=None, baseline_only=True)
+
+        mock_start.assert_not_called()
+        mock_predict.assert_not_called()
+
+    @patch("benchmarks.run_local._docker_stop")
+    @patch("benchmarks.run_local._docker_start")
+    @patch("benchmarks.run_local._wait_healthy")
+    @patch("benchmarks.run_local.run_compare")
+    @patch("benchmarks.run_local.run_score")
+    @patch("benchmarks.run_local.run_predict")
+    def test_baseline_only_skips_primary_predict_and_report(
+        self, mock_predict, mock_score, mock_compare, _mock_wait, _mock_start, _mock_stop,
+        tmp_path: Path,
+    ):
+        runs_dir = tmp_path / "runs"
+
+        def fake_score(_config, run_dir, _data_dir, **_kwargs):
+            self._make_summary(run_dir)
+
+        mock_score.side_effect = fake_score
+
+        run_local(_CONFIG, "smoke", "train", tmp_path / "data", runs_dir,
+                  parser_url="http://localhost:8080", parser_image=None, baseline_only=True)
+
+        mock_compare.assert_not_called()
+        assert mock_predict.call_count <= 1  # only baseline predict, no primary
+
+    @patch("benchmarks.run_local._docker_stop")
+    @patch("benchmarks.run_local._docker_start")
+    @patch("benchmarks.run_local._wait_healthy")
+    @patch("benchmarks.run_local.run_compare")
+    @patch("benchmarks.run_local.run_score")
+    @patch("benchmarks.run_local.run_predict")
+    def test_runs_comparison_report_when_parser_url_provided(
+        self, _mock_predict, mock_score, mock_compare, _mock_wait, _mock_start, _mock_stop,
+        tmp_path: Path,
+    ):
+        runs_dir = tmp_path / "runs"
+
+        def fake_score(_config, run_dir, _data_dir, **_kwargs):
+            self._make_summary(run_dir)
+
+        mock_score.side_effect = fake_score
+
+        run_local(_CONFIG, "smoke", "train", tmp_path / "data", runs_dir,
+                  parser_url="http://localhost:8080", parser_image="my-image:v1",
+                  baseline_only=False)
+
+        mock_compare.assert_called_once()
+        labeled_paths = mock_compare.call_args.args[0]
+        labels = [label for label, _ in labeled_paths]
+        assert "grobid 0.9.0-crf" in labels
+        assert "my-image:v1" in labels


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/73

Adds benchmarks/run_local.py to orchestrate a full local benchmark run: starts baseline tools (e.g. GROBID) via docker if predictions are absent, scores all tools, and produces a side-by-side comparison report. Predictions are stored under baselines/{tool}/{version}/{split}/ so version changes automatically trigger regeneration. Exposed via make dev-benchmark-with-baselines.