### PR TITLE
Add show-cases tool for per-document regression/improvement analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,13 @@ BENCHMARK_SPLIT ?= train
 BENCHMARK_RUN ?= benchmarks/runs/$(BENCHMARK_SPLIT)
 BENCHMARK_PARSER_URL ?= $(SCIENCEBEAM_PARSER_URL)
 
+SHOW_FIELD ?=
+SHOW_METHOD ?= edit_sim
+SHOW_CORPUS ?= biorxiv
+SHOW_LIMIT ?= 10
+SHOW_RUN_A ?= $(BENCHMARK_RUN)
+SHOW_RUN_B ?= $(shell python3 -c "import yaml; b=yaml.safe_load(open('benchmarks/eval.yml')).get('baselines',[]); print('benchmarks/runs/baselines/'+b[0]['tool']+'/'+b[0]['version']+'/$(BENCHMARK_SPLIT)') if b else print('')" 2>/dev/null)
+
 COMPARE_MODEL ?= segmentation
 COMPARE_DOC_ID ?= $(basename $(notdir $(COMPARE_PDF)))
 COMPARE_DOC_DIR = .temp/compare-with-grobid/by-doc/$(COMPARE_DOC_ID)
@@ -193,6 +200,32 @@ dev-benchmark-compare:
 
 
 dev-benchmark: dev-benchmark-predict dev-benchmark-score
+
+
+dev-show-regressions: .require-SHOW_FIELD
+	$(PYTHON) -m benchmarks.show_cases \
+		--run-a $(SHOW_RUN_A) \
+		--run-b $(SHOW_RUN_B) \
+		--field $(SHOW_FIELD) \
+		--method $(SHOW_METHOD) \
+		--corpus $(SHOW_CORPUS) \
+		--mode regression \
+		--data benchmarks/data \
+		--split $(BENCHMARK_SPLIT) \
+		--limit $(SHOW_LIMIT)
+
+
+dev-show-improvements: .require-SHOW_FIELD
+	$(PYTHON) -m benchmarks.show_cases \
+		--run-a $(SHOW_RUN_A) \
+		--run-b $(SHOW_RUN_B) \
+		--field $(SHOW_FIELD) \
+		--method $(SHOW_METHOD) \
+		--corpus $(SHOW_CORPUS) \
+		--mode improvement \
+		--data benchmarks/data \
+		--split $(BENCHMARK_SPLIT) \
+		--limit $(SHOW_LIMIT)
 
 
 dev-benchmark-with-baselines:

--- a/benchmarks/show_cases.py
+++ b/benchmarks/show_cases.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import logging
+import shutil
+from io import BytesIO
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from sciencebeam_judge.parsing.xml import parse_xml, parse_xml_mapping
+from sciencebeam_judge.parsing.xpath.xpath_functions import register_functions
+from sciencebeam_judge.resources import DEFAULT_XML_MAPPING_PATH
+
+LOGGER = logging.getLogger(__name__)
+
+_RESET = "\033[0m"
+_RED = "\033[91m"
+_GREEN = "\033[92m"
+
+
+def word_diff(reference: Optional[str], candidate: Optional[str]) -> str:
+    if reference is None and candidate is None:
+        return "(both absent)"
+    if reference is None:
+        return f"(gold absent) {_GREEN}{candidate}{_RESET}"
+    if candidate is None:
+        return f"{_RED}(prediction absent){_RESET}"
+    ref_words = reference.split()
+    cand_words = candidate.split()
+    matcher = difflib.SequenceMatcher(None, ref_words, cand_words, autojunk=False)
+    parts = []
+    for op, i1, i2, j1, j2 in matcher.get_opcodes():
+        if op == "equal":
+            parts.append(" ".join(ref_words[i1:i2]))
+        elif op == "replace":
+            parts.append(f"{_RED}[-{' '.join(ref_words[i1:i2])}-]{_RESET}")
+            parts.append(f"{_GREEN}{{+{' '.join(cand_words[j1:j2])}+}}{_RESET}")
+        elif op == "delete":
+            parts.append(f"{_RED}[-{' '.join(ref_words[i1:i2])}-]{_RESET}")
+        elif op == "insert":
+            parts.append(f"{_GREEN}{{+{' '.join(cand_words[j1:j2])}+}}{_RESET}")
+    return " ".join(parts)
+
+
+def _get_doc_score(field_scores: dict, method: str) -> Optional[float]:
+    ms = field_scores.get(method)
+    if ms is None:
+        return None
+    if "sim_sum" in ms:
+        ec = ms.get("expected_count", 0)
+        pc = ms.get("predicted_count", 0)
+        precision = ms["sim_sum"] / pc if pc else 0.0
+        recall = ms["sim_sum"] / ec if ec else 0.0
+        return (
+            2 * precision * recall / (precision + recall)
+            if (precision + recall)
+            else 0.0
+        )
+    return ms.get("f1")
+
+
+def _load_doc_score(score_path: Path, field: str, method: str) -> Optional[float]:
+    if not score_path.exists():
+        return None
+    data = json.loads(score_path.read_text(encoding="utf-8"))
+    return _get_doc_score(data.get("fields", {}).get(field, {}), method)
+
+
+def _extract_field_text(xml_path: Path, field: str, xml_mapping: dict) -> Optional[str]:
+    if not xml_path.exists():
+        return None
+    values = parse_xml(BytesIO(xml_path.read_bytes()), xml_mapping, fields=[field])
+    items = values.get(field, [])
+    return " | ".join(str(v) for v in items) if items else None
+
+
+def _run_label(run: Path) -> str:
+    parts = list(run.parts)
+    try:
+        idx = parts.index("runs")
+        return "/".join(parts[idx + 1:])
+    except ValueError:
+        return run.name
+
+
+def _comparison_label(run_b: Path) -> str:
+    """Derive a short label from run_b path for use in export directory names.
+
+    baselines/grobid/0.9.0-crf/train -> grobid-0.9.0-crf
+    """
+    label = _run_label(run_b)
+    if label.startswith("baselines/"):
+        label = label[len("baselines/"):]
+    # Strip trailing split segment (last path component)
+    parts = label.split("/")
+    if len(parts) > 1:
+        label = "/".join(parts[:-1])
+    return label.replace("/", "-")
+
+
+def find_cases(
+    run_a: Path,
+    run_b: Path,
+    field: str,
+    method: str,
+    corpus_filter: Optional[str],
+    mode: str,
+) -> List[Tuple[float, str, str, float, float]]:
+    """Return (delta, corpus, record_id, score_a, score_b) sorted by delta magnitude."""
+    if not (run_a / "scores").exists():
+        LOGGER.warning("No scores directory in %s", run_a)
+        return []
+
+    corpora = (
+        [corpus_filter]
+        if corpus_filter
+        else sorted(d.name for d in (run_a / "scores").iterdir() if d.is_dir())
+    )
+
+    cases = []
+    for corpus in corpora:
+        score_dir_a = run_a / "scores" / corpus
+        score_dir_b = run_b / "scores" / corpus
+        if not score_dir_a.exists():
+            continue
+        for score_path_a in sorted(score_dir_a.glob("*.json")):
+            score_a = _load_doc_score(score_path_a, field, method)
+            score_b = _load_doc_score(score_dir_b / score_path_a.name, field, method)
+            if score_a is None or score_b is None:
+                continue
+            delta = score_a - score_b
+            if mode == "regression" and delta < 0:
+                cases.append((delta, corpus, score_path_a.stem, score_a, score_b))
+            elif mode == "improvement" and delta > 0:
+                cases.append((delta, corpus, score_path_a.stem, score_a, score_b))
+
+    cases.sort(key=lambda x: x[0], reverse=mode == "improvement")
+    return cases
+
+
+def _extract_texts(
+    corpus: str,
+    record_id: str,
+    run_a: Path,
+    run_b: Path,
+    data_dir: Path,
+    split: str,
+    field: str,
+    xml_mapping: dict,
+) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    gold_path = data_dir / split / corpus / f"{record_id}.jats.xml"
+    pred_path_a = run_a / "predictions" / corpus / f"{record_id}.tei.xml"
+    pred_path_b = run_b / "predictions" / corpus / f"{record_id}.tei.xml"
+    gold_text = _extract_field_text(gold_path, field, xml_mapping)
+    text_a = _extract_field_text(pred_path_a, field, xml_mapping)
+    text_b = _extract_field_text(pred_path_b, field, xml_mapping)
+    return gold_text, text_a, text_b
+
+
+def _print_case(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    delta: float,
+    corpus: str,
+    record_id: str,
+    score_a: float,
+    score_b: float,
+    label_a: str,
+    label_b: str,
+    gold_text: Optional[str],
+    text_a: Optional[str],
+    text_b: Optional[str],
+) -> None:
+    width = max(len(label_a), len(label_b), 4)
+    print(f"record : {corpus}/{record_id}  Δ={delta:+.3f}")
+    if gold_text is not None:
+        print(f"  {'gold':<{width}} : {gold_text}")
+    print(f"  {label_a:<{width}} : {score_a:.3f} | {word_diff(gold_text, text_a)}")
+    print(f"  {label_b:<{width}} : {score_b:.3f} | {word_diff(gold_text, text_b)}")
+    print()
+
+
+def _copy_if_exists(src: Path, dst: Path) -> None:
+    if src.exists():
+        shutil.copy(src, dst)
+
+
+def _export_case(
+    out_dir: Path,
+    record_id: str,
+    corpus: str,
+    field: str,
+    gold_text: Optional[str],
+    text_a: Optional[str],
+    text_b: Optional[str],
+    run_a: Path,
+    run_b: Path,
+    data_dir: Path,
+    split: str,
+) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for suffix, text in [
+        (f"{record_id}.gold.{field}.txt", gold_text),
+        (f"{record_id}.run-a.{field}.txt", text_a),
+        (f"{record_id}.run-b.{field}.txt", text_b),
+    ]:
+        (out_dir / suffix).write_text(text or "", encoding="utf-8")
+    _copy_if_exists(
+        data_dir / split / corpus / f"{record_id}.pdf", out_dir / f"{record_id}.pdf"
+    )
+    _copy_if_exists(
+        data_dir / split / corpus / f"{record_id}.jats.xml",
+        out_dir / f"{record_id}.jats.xml",
+    )
+    _copy_if_exists(
+        run_a / "predictions" / corpus / f"{record_id}.tei.xml",
+        out_dir / f"{record_id}.run-a.tei.xml",
+    )
+    _copy_if_exists(
+        run_b / "predictions" / corpus / f"{record_id}.tei.xml",
+        out_dir / f"{record_id}.run-b.tei.xml",
+    )
+
+
+def run_show_cases(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    # pylint: disable=too-many-locals
+    run_a: Path,
+    run_b: Path,
+    field: str,
+    method: str,
+    corpus: Optional[str],
+    mode: str,
+    data_dir: Path,
+    split: str,
+    limit: Optional[int],
+) -> None:
+    register_functions()
+    xml_mapping = parse_xml_mapping(DEFAULT_XML_MAPPING_PATH)
+
+    label_a = _run_label(run_a)
+    label_b = _run_label(run_b)
+    comp_label = _comparison_label(run_b)
+
+    cases = find_cases(run_a, run_b, field, method, corpus, mode)
+    corpus_label = corpus or "all corpora"
+    print(f"{len(cases)} {mode}s: {field}/{method} ({corpus_label})")
+    print(f"  run-a ({label_a}): {run_a}")
+    print(f"  run-b ({label_b}): {run_b}")
+    print()
+
+    to_show = cases[:limit] if limit is not None else cases
+    examples_base = run_a / "examples" / f"vs-{comp_label}" / mode / field / method
+    for delta, corp, record_id, score_a, score_b in to_show:
+        gold_text, text_a, text_b = _extract_texts(
+            corp, record_id, run_a, run_b, data_dir, split, field, xml_mapping,
+        )
+        _print_case(
+            delta, corp, record_id, score_a, score_b,
+            label_a, label_b, gold_text, text_a, text_b,
+        )
+        _export_case(
+            examples_base / corp, record_id, corp, field,
+            gold_text, text_a, text_b,
+            run_a, run_b, data_dir, split,
+        )
+
+    if to_show:
+        print(f"Exported {len(to_show)} examples to {examples_base}")
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Show per-document regressions or improvements between two runs"
+    )
+    parser.add_argument("--run-a", required=True, type=Path, help="Primary run directory")
+    parser.add_argument("--run-b", required=True, type=Path, help="Baseline run directory")
+    parser.add_argument("--field", required=True, help="Field name, e.g. title")
+    parser.add_argument(
+        "--method", default="edit_sim", help="Scoring method (default: edit_sim)"
+    )
+    parser.add_argument("--corpus", default=None, help="Corpus filter (default: all)")
+    parser.add_argument("--mode", required=True, choices=["regression", "improvement"])
+    parser.add_argument("--data", default="benchmarks/data", type=Path)
+    parser.add_argument("--split", default="train")
+    parser.add_argument("--limit", type=int, default=10)
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(message)s")
+
+    run_show_cases(
+        run_a=args.run_a,
+        run_b=args.run_b,
+        field=args.field,
+        method=args.method,
+        corpus=args.corpus,
+        mode=args.mode,
+        data_dir=args.data,
+        split=args.split,
+        limit=args.limit,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/tests/show_cases_test.py
+++ b/benchmarks/tests/show_cases_test.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmarks.show_cases import (
+    _comparison_label,
+    _copy_if_exists,
+    _export_case,
+    _get_doc_score,
+    _run_label,
+    find_cases,
+    word_diff,
+)
+
+
+class TestGetDocScore:
+    def test_binary_returns_f1(self):
+        ms = {"true_positive": 1, "false_positive": 0, "false_negative": 0, "f1": 1.0}
+        assert _get_doc_score({"levenshtein": ms}, "levenshtein") == 1.0
+
+    def test_continuous_computes_from_sim_sum(self):
+        ms = {"sim_sum": 0.8, "expected_count": 1, "predicted_count": 1, "f1": 0.0}
+        assert _get_doc_score({"edit_sim": ms}, "edit_sim") == pytest.approx(0.8)
+
+    def test_continuous_returns_zero_when_both_absent(self):
+        ms = {"sim_sum": 0.0, "expected_count": 0, "predicted_count": 0, "f1": 0.0}
+        assert _get_doc_score({"edit_sim": ms}, "edit_sim") == 0.0
+
+    def test_returns_none_for_missing_method(self):
+        assert _get_doc_score({}, "edit_sim") is None
+
+    def test_continuous_precision_recall_harmonic(self):
+        # sim_sum=0.6, ec=1, pc=2 → precision=0.3, recall=0.6 → f1=0.4
+        ms = {"sim_sum": 0.6, "expected_count": 1, "predicted_count": 2, "f1": 0.0}
+        result = _get_doc_score({"edit_sim": ms}, "edit_sim")
+        assert result == pytest.approx(0.4, abs=1e-6)
+
+
+class TestWordDiff:
+    def test_identical_strings_show_no_markers(self):
+        result = word_diff("hello world", "hello world")
+        assert "[-" not in result
+        assert "{+" not in result
+
+    def test_substitution_shows_red_and_green(self):
+        result = word_diff("hello world", "hello earth")
+        assert "[-world-]" in result
+        assert "{+earth+}" in result
+
+    def test_deletion_shows_red(self):
+        result = word_diff("hello world", "hello")
+        assert "[-world-]" in result
+
+    def test_insertion_shows_green(self):
+        result = word_diff("hello", "hello world")
+        assert "{+world+}" in result
+
+    def test_both_none(self):
+        assert word_diff(None, None) == "(both absent)"
+
+    def test_gold_none(self):
+        result = word_diff(None, "prediction")
+        assert "gold absent" in result
+        assert "prediction" in result
+
+    def test_candidate_none(self):
+        result = word_diff("gold", None)
+        assert "prediction absent" in result
+
+
+class TestRunLabel:
+    def test_extracts_path_after_runs(self, tmp_path: Path):
+        run = tmp_path / "benchmarks" / "runs" / "train"
+        assert _run_label(run) == "train"
+
+    def test_extracts_baseline_path(self, tmp_path: Path):
+        run = tmp_path / "benchmarks" / "runs" / "baselines" / "grobid" / "0.9.0-crf" / "train"
+        assert _run_label(run) == "baselines/grobid/0.9.0-crf/train"
+
+    def test_falls_back_to_name_when_no_runs_segment(self, tmp_path: Path):
+        run = tmp_path / "some" / "other" / "path"
+        assert _run_label(run) == "path"
+
+
+class TestComparisonLabel:
+    def test_baseline_grobid_strips_prefix_and_split(self, tmp_path: Path):
+        run_b = tmp_path / "runs" / "baselines" / "grobid" / "0.9.0-crf" / "train"
+        assert _comparison_label(run_b) == "grobid-0.9.0-crf"
+
+    def test_non_baseline_strips_split_only(self, tmp_path: Path):
+        run_b = tmp_path / "runs" / "train"
+        assert _comparison_label(run_b) == "train"
+
+    def test_no_runs_segment_uses_name(self, tmp_path: Path):
+        run_b = tmp_path / "some" / "path" / "train"
+        assert _comparison_label(run_b) == "train"
+
+
+def _make_export_case_call(
+    out_dir: Path, tmp_path: Path,
+    gold_text=None, text_a=None, text_b=None,
+    with_source_files=False,
+):
+    run_a = tmp_path / "run_a"
+    run_b = tmp_path / "run_b"
+    data_dir = tmp_path / "data"
+    if with_source_files:
+        (data_dir / "train" / "biorxiv").mkdir(parents=True, exist_ok=True)
+        (data_dir / "train" / "biorxiv" / "doc1.pdf").write_bytes(b"pdf")
+        (data_dir / "train" / "biorxiv" / "doc1.jats.xml").write_bytes(b"<jats/>")
+        (run_a / "predictions" / "biorxiv").mkdir(parents=True, exist_ok=True)
+        (run_a / "predictions" / "biorxiv" / "doc1.tei.xml").write_bytes(b"<tei-a/>")
+        (run_b / "predictions" / "biorxiv").mkdir(parents=True, exist_ok=True)
+        (run_b / "predictions" / "biorxiv" / "doc1.tei.xml").write_bytes(b"<tei-b/>")
+    _export_case(
+        out_dir, "doc1", "biorxiv", "title",
+        gold_text, text_a, text_b,
+        run_a, run_b, data_dir, "train",
+    )
+
+
+class TestCopyIfExists:
+    def test_copies_when_src_exists(self, tmp_path: Path):
+        src = tmp_path / "src.txt"
+        src.write_text("hello")
+        dst = tmp_path / "dst.txt"
+        _copy_if_exists(src, dst)
+        assert dst.read_text() == "hello"
+
+    def test_does_nothing_when_src_missing(self, tmp_path: Path):
+        _copy_if_exists(tmp_path / "missing.txt", tmp_path / "dst.txt")
+        assert not (tmp_path / "dst.txt").exists()
+
+
+class TestExportCase:
+    def test_writes_text_files(self, tmp_path: Path):
+        out_dir = tmp_path / "examples"
+        _make_export_case_call(out_dir, tmp_path, "gold text", "pred a", "pred b")
+        assert (out_dir / "doc1.gold.title.txt").read_text() == "gold text"
+        assert (out_dir / "doc1.run-a.title.txt").read_text() == "pred a"
+        assert (out_dir / "doc1.run-b.title.txt").read_text() == "pred b"
+
+    def test_creates_output_directory(self, tmp_path: Path):
+        out_dir = tmp_path / "deep" / "nested" / "dir"
+        _make_export_case_call(out_dir, tmp_path)
+        assert out_dir.is_dir()
+
+    def test_writes_empty_string_for_none(self, tmp_path: Path):
+        out_dir = tmp_path / "examples"
+        _make_export_case_call(out_dir, tmp_path)
+        assert (out_dir / "doc1.gold.title.txt").read_text() == ""
+        assert (out_dir / "doc1.run-a.title.txt").read_text() == ""
+        assert (out_dir / "doc1.run-b.title.txt").read_text() == ""
+
+    def test_copies_source_files_when_present(self, tmp_path: Path):
+        out_dir = tmp_path / "examples"
+        _make_export_case_call(out_dir, tmp_path, with_source_files=True)
+        assert (out_dir / "doc1.pdf").read_bytes() == b"pdf"
+        assert (out_dir / "doc1.jats.xml").read_bytes() == b"<jats/>"
+        assert (out_dir / "doc1.run-a.tei.xml").read_bytes() == b"<tei-a/>"
+        assert (out_dir / "doc1.run-b.tei.xml").read_bytes() == b"<tei-b/>"
+
+    def test_skips_missing_source_files(self, tmp_path: Path):
+        out_dir = tmp_path / "examples"
+        _make_export_case_call(out_dir, tmp_path, with_source_files=False)
+        assert not (out_dir / "doc1.pdf").exists()
+        assert not (out_dir / "doc1.jats.xml").exists()
+        assert not (out_dir / "doc1.run-a.tei.xml").exists()
+        assert not (out_dir / "doc1.run-b.tei.xml").exists()
+
+
+class TestFindCases:
+    def _write_score(self, path: Path, field: str, method: str, value: float) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        ms: dict
+        if method == "edit_sim":
+            ms = {"sim_sum": value, "expected_count": 1, "predicted_count": 1, "f1": 0.0}
+        else:
+            tp = 1 if value == 1.0 else 0
+            ms = {"true_positive": tp, "false_positive": 1 - tp,
+                  "false_negative": 1 - tp, "f1": value}
+        path.write_text(json.dumps({
+            "record_id": path.stem,
+            "corpus": path.parent.name,
+            "fields": {field: {"scoring_type": "string", method: ms}},
+        }))
+
+    def test_finds_regressions(self, tmp_path: Path):
+        run_a = tmp_path / "run_a"
+        run_b = tmp_path / "run_b"
+        self._write_score(run_a / "scores" / "biorxiv" / "doc1.json", "title", "edit_sim", 0.5)
+        self._write_score(run_b / "scores" / "biorxiv" / "doc1.json", "title", "edit_sim", 0.8)
+
+        cases = find_cases(run_a, run_b, "title", "edit_sim", None, "regression")
+        assert len(cases) == 1
+        delta, corpus, record_id, score_a, score_b = cases[0]
+        assert corpus == "biorxiv"
+        assert record_id == "doc1"
+        assert delta == pytest.approx(-0.3, abs=1e-6)
+        assert score_a == pytest.approx(0.5)
+        assert score_b == pytest.approx(0.8)
+
+    def test_finds_improvements(self, tmp_path: Path):
+        run_a = tmp_path / "run_a"
+        run_b = tmp_path / "run_b"
+        self._write_score(run_a / "scores" / "biorxiv" / "doc1.json", "title", "edit_sim", 0.9)
+        self._write_score(run_b / "scores" / "biorxiv" / "doc1.json", "title", "edit_sim", 0.6)
+
+        cases = find_cases(run_a, run_b, "title", "edit_sim", None, "improvement")
+        assert len(cases) == 1
+        assert cases[0][0] == pytest.approx(0.3, abs=1e-6)
+
+    def test_excludes_equal_scores(self, tmp_path: Path):
+        run_a = tmp_path / "run_a"
+        run_b = tmp_path / "run_b"
+        self._write_score(run_a / "scores" / "biorxiv" / "doc1.json", "title", "edit_sim", 0.8)
+        self._write_score(run_b / "scores" / "biorxiv" / "doc1.json", "title", "edit_sim", 0.8)
+
+        assert not find_cases(run_a, run_b, "title", "edit_sim", None, "regression")
+        assert not find_cases(run_a, run_b, "title", "edit_sim", None, "improvement")
+
+    def test_skips_when_run_b_score_missing(self, tmp_path: Path):
+        run_a = tmp_path / "run_a"
+        run_b = tmp_path / "run_b"
+        self._write_score(run_a / "scores" / "biorxiv" / "doc1.json", "title", "edit_sim", 0.5)
+
+        assert not find_cases(run_a, run_b, "title", "edit_sim", None, "regression")
+
+    def test_corpus_filter(self, tmp_path: Path):
+        run_a = tmp_path / "run_a"
+        run_b = tmp_path / "run_b"
+        self._write_score(run_a / "scores" / "biorxiv" / "doc1.json", "title", "edit_sim", 0.5)
+        self._write_score(run_b / "scores" / "biorxiv" / "doc1.json", "title", "edit_sim", 0.9)
+        self._write_score(run_a / "scores" / "pmc" / "doc2.json", "title", "edit_sim", 0.5)
+        self._write_score(run_b / "scores" / "pmc" / "doc2.json", "title", "edit_sim", 0.9)
+
+        cases = find_cases(run_a, run_b, "title", "edit_sim", "biorxiv", "regression")
+        assert len(cases) == 1
+        assert cases[0][1] == "biorxiv"
+
+    def test_regressions_sorted_worst_first(self, tmp_path: Path):
+        run_a = tmp_path / "run_a"
+        run_b = tmp_path / "run_b"
+        self._write_score(run_a / "scores" / "biorxiv" / "doc1.json", "title", "edit_sim", 0.7)
+        self._write_score(run_b / "scores" / "biorxiv" / "doc1.json", "title", "edit_sim", 0.9)
+        self._write_score(run_a / "scores" / "biorxiv" / "doc2.json", "title", "edit_sim", 0.4)
+        self._write_score(run_b / "scores" / "biorxiv" / "doc2.json", "title", "edit_sim", 0.9)
+
+        cases = find_cases(run_a, run_b, "title", "edit_sim", None, "regression")
+        assert cases[0][2] == "doc2"  # worse regression first
+
+    def test_returns_empty_when_no_scores_dir(self, tmp_path: Path):
+        run_a = tmp_path / "run_a"
+        run_b = tmp_path / "run_b"
+        assert not find_cases(run_a, run_b, "title", "edit_sim", None, "regression")


### PR DESCRIPTION
Introduces benchmarks/show_cases.py with word-level diffs and file export, and Makefile targets dev-show-regressions / dev-show-improvements.

Per-case exports include the field text files alongside the source PDF, gold JATS XML, and both run TEI XMLs so regressions can be inspected end-to-end without leaving the examples directory.

SHOW_RUN_B defaults to the first baseline from eval.yml so the common comparison requires no extra arguments beyond SHOW_FIELD.