### PR TITLE
Add ore, pkp, scielo_br, scielo_mx, scielo_preprints-jats corpora to eval.yml

### DIFF
--- a/benchmarks/eval.yml
+++ b/benchmarks/eval.yml
@@ -7,17 +7,69 @@ dataset:
         file: biorxiv-jats/train-00000-of-00001.parquet
         id_column: ppr_id
         variant: v1
+      ore:
+        file: ore-jats/train-00000-of-00001.parquet
+        id_column: ppr_id
+        variant: v1
+      pkp:
+        file: pkp-jats/train-00000-of-00001.parquet
+        id_column: ppr_id
+        variant: v1
+      scielo_br:
+        file: scielo_br-jats/train-00000-of-00001.parquet
+        id_column: ppr_id
+        variant: v1
+      scielo_mx:
+        file: scielo_mx-jats/train-00000-of-00001.parquet
+        id_column: ppr_id
+        variant: v1
+      scielo_preprints-jats:
+        file: scielo-preprints-jats/train-00000-of-00001.parquet
+        id_column: ppr_id
+        variant: v1
     validation:
       biorxiv:
         file: biorxiv-jats/validation-00000-of-00001.parquet
         id_column: ppr_id
         variant: v1
+      ore:
+        file: ore-jats/validation-00000-of-00001.parquet
+        id_column: ppr_id
+        variant: v1
+      pkp:
+        file: pkp-jats/validation-00000-of-00001.parquet
+        id_column: ppr_id
+        variant: v1
+      scielo_br:
+        file: scielo_br-jats/validation-00000-of-00001.parquet
+        id_column: ppr_id
+        variant: v1
+      scielo_mx:
+        file: scielo_mx-jats/validation-00000-of-00001.parquet
+        id_column: ppr_id
+        variant: v1
+      scielo_preprints-jats:
+        file: scielo-preprints-jats/validation-00000-of-00001.parquet
+        id_column: ppr_id
+        variant: v1
 
+# Dataset row counts at revision main:
+#   biorxiv: 158, ore: 199, pkp: 200, scielo_br: 200, scielo_mx: 112, scielo_preprints-jats: 1000
 sampling:
   smoke:
     biorxiv: 10
+    ore: 10
+    pkp: 10
+    scielo_br: 10
+    scielo_mx: 10
+    scielo_preprints-jats: 10
   full:
     biorxiv: 158
+    ore: 199
+    pkp: 200
+    scielo_br: 200
+    scielo_mx: 112
+    scielo_preprints-jats: 1000
 
 seeds:
   sample: 42

--- a/benchmarks/report.py
+++ b/benchmarks/report.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import logging
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 LOGGER = logging.getLogger(__name__)
 
@@ -27,6 +27,19 @@ def _get_f1(
     return None
 
 
+def _get_overall_f1(summary: dict, field: str, method: str) -> Optional[float]:
+    """Doc-count-weighted mean F1 across all corpora."""
+    total_n = 0
+    weighted = 0.0
+    for corpus, corpus_data in summary.get("corpora", {}).items():
+        n = corpus_data.get("n", 0)
+        f1 = _get_f1(summary, corpus, field, method)
+        if f1 is not None and n > 0:
+            total_n += n
+            weighted += n * f1
+    return weighted / total_n if total_n > 0 else None
+
+
 def _fmt_f1(f1: Optional[float]) -> str:
     return f"{f1:.3f}" if f1 is not None else "—"
 
@@ -35,57 +48,91 @@ def _fmt_delta(delta: Optional[float]) -> str:
     return f"{delta:+.3f}" if delta is not None else "—"
 
 
-def _render_corpus_section(  # pylint: disable=too-many-locals
+def _corpus_f1_getter(corpus: str) -> Callable[[dict, str, str], Optional[float]]:
+    return lambda s, f, m: _get_f1(s, corpus, f, m)
+
+
+def _render_field_table(  # pylint: disable=too-many-locals
+    labeled_summaries: List[Tuple[str, dict]],
+    field_names: List[str],
+    field_measures: dict,
+    field_scoring_types: dict,
+    get_f1_fn: Callable[[dict, str, str], Optional[float]],
+) -> List[str]:
+    """Render comparison table. get_f1_fn(summary, field, method) -> Optional[float]."""
+    primary_label, _ = labeled_summaries[-1]
+    others = labeled_summaries[:-1]
+    other_labels = [label for label, _ in others]
+
+    col_labels = other_labels + [primary_label] + [f"Δ {lbl}" for lbl in other_labels]
+    n_cols = 2 * len(others) + 3
+    lines = [
+        "| Field (method) | Type | " + " | ".join(col_labels) + " |",
+        "|" + "|".join(["---"] * n_cols) + "|",
+    ]
+
+    for field in field_names:
+        methods = field_measures.get(field, [])
+        field_type = field_scoring_types.get(field, "string")
+        for method in methods:
+            primary_f1 = get_f1_fn(labeled_summaries[-1][1], field, method)
+            other_f1s = [get_f1_fn(s, field, method) for _, s in others]
+            deltas = [
+                _fmt_delta(
+                    primary_f1 - f1 if primary_f1 is not None and f1 is not None else None
+                )
+                for f1 in other_f1s
+            ]
+            cells = [_fmt_f1(f1) for f1 in other_f1s] + [_fmt_f1(primary_f1)] + deltas
+            lines.append(f"| {field} ({method}) | {field_type} | " + " | ".join(cells) + " |")
+
+    return lines
+
+
+def _render_corpus_section(
     corpus: str,
     labeled_summaries: List[Tuple[str, dict]],
     field_names: List[str],
     field_measures: dict,
     field_scoring_types: dict,
 ) -> List[str]:
-    primary_label, primary_summary = labeled_summaries[-1]
-    others = labeled_summaries[:-1]
-    other_labels = [label for label, _ in others]
-
-    lines: List[str] = []
-
     counts = " | ".join(
         f"**{label}**: {s.get('corpora', {}).get(corpus, {}).get('n', 0)} docs"
         for label, s in labeled_summaries
     )
-    lines.append(counts)
-    lines.append("")
+    lines = [counts, ""]
+    lines.extend(_render_field_table(
+        labeled_summaries, field_names, field_measures, field_scoring_types,
+        _corpus_f1_getter(corpus),
+    ))
+    return lines
 
-    col_labels = (
-        list(other_labels)
-        + [primary_label]
-        + [f"Δ {label}" for label in other_labels]
+
+def _render_overall_section(  # pylint: disable=too-many-locals
+    labeled_summaries: List[Tuple[str, dict]],
+    field_names: List[str],
+    field_measures: dict,
+    field_scoring_types: dict,
+    corpora: List[str],
+) -> List[str]:
+    _, primary_summary = labeled_summaries[-1]
+    n_total = sum(
+        primary_summary.get("corpora", {}).get(c, {}).get("n", 0) for c in corpora
     )
-    lines.append("| Field (method) | Type | " + " | ".join(col_labels) + " |")
-
-    n_cols = 2 * len(others) + 3  # field, type, others, primary, delta-per-other
-    lines.append("|" + "|".join(["---"] * n_cols) + "|")
-
-    for field in field_names:
-        methods = field_measures.get(field, [])
-        field_type = field_scoring_types.get(field, "string")
-        for method in methods:
-            primary_f1 = _get_f1(primary_summary, corpus, field, method)
-            other_f1s = [_get_f1(s, corpus, field, method) for _, s in others]
-            deltas = [
-                _fmt_delta(
-                    primary_f1 - f1
-                    if primary_f1 is not None and f1 is not None
-                    else None
-                )
-                for f1 in other_f1s
-            ]
-            cells = (
-                [_fmt_f1(f1) for f1 in other_f1s]
-                + [_fmt_f1(primary_f1)]
-                + deltas
-            )
-            lines.append(f"| {field} ({method}) | {field_type} | " + " | ".join(cells) + " |")
-
+    total_counts = " | ".join(
+        f"**{label}**: {sum(s.get('corpora', {}).get(c, {}).get('n', 0) for c in corpora)} docs"
+        for label, s in labeled_summaries
+    )
+    lines = [
+        f"### Overall ({n_total} docs across {len(corpora)} corpora)",
+        "",
+        total_counts,
+        "",
+    ]
+    lines.extend(_render_field_table(
+        labeled_summaries, field_names, field_measures, field_scoring_types,
+        _get_overall_f1,
+    ))
     return lines
 
 
@@ -102,15 +149,27 @@ def _render_comparison_report(
     corpora = list(primary_summary.get("corpora", {}).keys())
 
     lines = ["## ScienceBeam Parser Evaluation", ""]
+
+    if len(corpora) > 1:
+        lines.extend(_render_overall_section(
+            labeled_summaries, field_names, field_measures, field_scoring_types, corpora,
+        ))
+        lines.append("")
+
     for corpus in corpora:
-        lines.append(f"### {corpus}")
-        lines.append("")
-        lines.extend(
-            _render_corpus_section(
-                corpus, labeled_summaries, field_names, field_measures, field_scoring_types
-            )
+        n_primary = primary_summary.get("corpora", {}).get(corpus, {}).get("n", 0)
+        corpus_lines = _render_corpus_section(
+            corpus, labeled_summaries, field_names, field_measures, field_scoring_types,
         )
-        lines.append("")
+        lines += [
+            "<details>",
+            f"<summary><b>{corpus}</b> ({n_primary} docs)</summary>",
+            "",
+            *corpus_lines,
+            "",
+            "</details>",
+            "",
+        ]
 
     return "\n".join(lines)
 

--- a/benchmarks/tests/report_test.py
+++ b/benchmarks/tests/report_test.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+from typing import Optional
+
 import pytest
 
-from benchmarks.report import _get_f1, _parse_labeled_summary, _render_comparison_report
+from benchmarks.report import (
+    _get_f1,
+    _get_overall_f1,
+    _parse_labeled_summary,
+    _render_comparison_report,
+)
 
 
 def _agg(scoring_type: str, method: str, by_field: dict) -> dict:
@@ -28,12 +35,19 @@ def _corpus(aggregated: list, n: int = 10) -> dict:
     return {"biorxiv": {"n": n, "aggregated": aggregated}}
 
 
-def _title_summary(f1: float, method: str = "levenshtein") -> dict:
+def _multi_corpus(names: list, aggregated: list, n: int = 10) -> dict:
+    return {name: {"n": n, "aggregated": aggregated} for name in names}
+
+
+def _title_summary(f1: float, method: str = "levenshtein", corpora: Optional[dict] = None) -> dict:
     return _summary(
         fields=["title"],
         field_measures={"title": [method]},
         field_scoring_types={"title": "string"},
-        corpora=_corpus([_agg("string", method, {"title": f1})]),
+        corpora=(
+            corpora if corpora is not None
+            else _corpus([_agg("string", method, {"title": f1})])
+        ),
     )
 
 
@@ -69,6 +83,50 @@ class TestGetF1:
         assert _get_f1(s, "biorxiv", "title", "exact") is None
 
 
+class TestGetOverallF1:
+    def test_single_corpus_matches_corpus_f1(self):
+        s = _title_summary(0.85)
+        assert _get_overall_f1(s, "title", "levenshtein") == pytest.approx(0.85)
+
+    def test_weighted_mean_across_corpora(self):
+        # biorxiv: n=10, f1=0.8 → weight 8.0
+        # ore:     n=20, f1=0.6 → weight 12.0
+        # overall: 20/30 ≈ 0.667
+        s = _summary(
+            fields=["title"],
+            field_measures={"title": ["levenshtein"]},
+            field_scoring_types={"title": "string"},
+            corpora={
+                "biorxiv": {"n": 10, "aggregated": [_agg("string", "levenshtein", {"title": 0.8})]},
+                "ore": {"n": 20, "aggregated": [_agg("string", "levenshtein", {"title": 0.6})]},
+            },
+        )
+        assert _get_overall_f1(s, "title", "levenshtein") == pytest.approx(20 / 30, abs=1e-6)
+
+    def test_skips_corpus_with_missing_f1(self):
+        s = _summary(
+            fields=["title"],
+            field_measures={"title": ["levenshtein"]},
+            field_scoring_types={"title": "string"},
+            corpora={
+                "biorxiv": {"n": 10, "aggregated": [_agg("string", "levenshtein", {"title": 0.8})]},
+                "ore": {"n": 20, "aggregated": [_agg("string", "levenshtein", {})]},
+            },
+        )
+        assert _get_overall_f1(s, "title", "levenshtein") == pytest.approx(0.8)
+
+    def test_returns_none_when_no_corpora_have_f1(self):
+        s = _summary(
+            fields=["title"],
+            field_measures={"title": ["levenshtein"]},
+            field_scoring_types={"title": "string"},
+            corpora={
+                "biorxiv": {"n": 10, "aggregated": [_agg("string", "levenshtein", {})]},
+            },
+        )
+        assert _get_overall_f1(s, "title", "levenshtein") is None
+
+
 class TestParseLabeledSummary:
     def test_simple_label_and_path(self):
         label, path = _parse_labeled_summary("GROBID=runs/grobid/summary.json")
@@ -90,11 +148,19 @@ class TestParseLabeledSummary:
         assert str(path) == "benchmarks/runs/baseline/summary.json"
 
 
-class TestRenderComparisonReport:
+class TestRenderComparisonReport:  # pylint: disable=too-many-public-methods
     def _two(self, grobid_f1=0.820, sb_f1=0.852):
         return [
             ("GROBID 0.9.0-crf", _title_summary(grobid_f1)),
             ("ScienceBeam (PR)", _title_summary(sb_f1)),
+        ]
+
+    def _two_multi_corpus(self, grobid_f1=0.820, sb_f1=0.852):
+        agg_g = [_agg("string", "levenshtein", {"title": grobid_f1})]
+        agg_s = [_agg("string", "levenshtein", {"title": sb_f1})]
+        return [
+            ("GROBID", _title_summary(grobid_f1, corpora=_multi_corpus(["biorxiv", "ore"], agg_g))),
+            ("SB (PR)", _title_summary(sb_f1, corpora=_multi_corpus(["biorxiv", "ore"], agg_s))),
         ]
 
     def test_returns_empty_string_for_empty_input(self):
@@ -185,3 +251,35 @@ class TestRenderComparisonReport:
         header = next(line for line in report.splitlines() if "Field (method)" in line)
         assert "Δ" not in header
         assert "0.852" in report
+
+    def test_corpus_section_is_collapsible(self):
+        report = _render_comparison_report(self._two())
+        assert "<details>" in report
+        assert "<summary><b>biorxiv</b>" in report
+        assert "</details>" in report
+
+    def test_no_overall_section_for_single_corpus(self):
+        report = _render_comparison_report(self._two())
+        assert "### Overall" not in report
+
+    def test_overall_section_present_for_multiple_corpora(self):
+        report = _render_comparison_report(self._two_multi_corpus())
+        assert "### Overall" in report
+        assert "2 corpora" in report
+
+    def test_overall_section_shows_total_doc_count(self):
+        report = _render_comparison_report(self._two_multi_corpus())
+        # 2 corpora × 10 docs each = 20 total
+        assert "20 docs" in report
+
+    def test_overall_section_weighted_f1(self):
+        # both corpora same n=10 → simple mean
+        report = _render_comparison_report(self._two_multi_corpus(grobid_f1=0.800, sb_f1=0.840))
+        assert "0.840" in report  # sb overall F1
+        assert "0.800" in report  # grobid overall F1
+
+    def test_each_corpus_has_collapsible_section(self):
+        report = _render_comparison_report(self._two_multi_corpus())
+        assert report.count("<details>") == 2
+        assert "<summary><b>biorxiv</b>" in report
+        assert "<summary><b>ore</b>" in report


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/83

Extends both train and validation splits with the five additional corpora from the sciencebeam-v2-benchmarking dataset. Smoke sampling stays at 10 per corpus; full counts match the dataset row counts. No code changes needed — predict.py and score.py already iterate over the split's corpus keys dynamically.