### PR TITLE
Add configurable pretty-printing for TEI XML output

### DIFF
--- a/sciencebeam_parser/app/parser.py
+++ b/sciencebeam_parser/app/parser.py
@@ -137,8 +137,11 @@ def get_xml_tree(xml_root: etree.ElementBase) -> etree._ElementTree:
 
 def serialize_xml_to_file(
     xml_root: etree.ElementBase,
-    filename: str
+    filename: str,
+    pretty_print: bool = False
 ):
+    if pretty_print:
+        etree.indent(xml_root, space='  ')
     get_xml_tree(xml_root).write(
         filename,
         encoding='utf-8',
@@ -300,8 +303,11 @@ class ScienceBeamParserSessionParsedSemanticDocument(_ScienceBeamParserSessionDe
         xml_root: etree.ElementBase,
         filename: str
     ) -> str:
+        pretty_print = self.session.parser.config.get('output', {}).get(
+            'pretty_print_xml', True
+        )
         start = monotonic()
-        serialize_xml_to_file(xml_root, filename=filename)
+        serialize_xml_to_file(xml_root, filename=filename, pretty_print=pretty_print)
         end = monotonic()
         LOGGER.info('serializing xml, took=%.3fs', end - start)
         return filename

--- a/sciencebeam_parser/resources/default_config/config.yml
+++ b/sciencebeam_parser/resources/default_config/config.yml
@@ -135,5 +135,8 @@ doc_to_pdf:
     remove_header_footer: true
     remove_redline: true
 
+output:
+  pretty_print_xml: true
+
 # preload resources and models on startup
 preload_on_startup: false

--- a/tests/app/parser_test.py
+++ b/tests/app/parser_test.py
@@ -21,7 +21,8 @@ from sciencebeam_parser.app.parser import (
     ScienceBeamParser,
     ScienceBeamParserSession,
     UnsupportedRequestMediaTypeScienceBeamParserError,
-    UnsupportedResponseMediaTypeScienceBeamParserError
+    UnsupportedResponseMediaTypeScienceBeamParserError,
+    serialize_xml_to_file
 )
 
 
@@ -144,6 +145,43 @@ def _sciencebeam_parser_session(
         yield session
 
 
+class TestSerializeXmlToFile:
+    def test_should_indent_structural_elements_when_pretty_print(
+        self, tmp_path: Path
+    ):
+        root = etree.fromstring(
+            b'<TEI><teiHeader><title>My Title</title></teiHeader></TEI>'
+        )
+        filename = str(tmp_path / 'output.xml')
+        serialize_xml_to_file(root, filename, pretty_print=True)
+        content = Path(filename).read_text(encoding='utf-8')
+        assert '\n' in content
+        assert 'My Title' in content
+
+    def test_should_preserve_mixed_content_text_when_pretty_print(
+        self, tmp_path: Path
+    ):
+        root = etree.fromstring(
+            b'<TEI><p>some text <ref>1</ref> more text</p></TEI>'
+        )
+        filename = str(tmp_path / 'output.xml')
+        serialize_xml_to_file(root, filename, pretty_print=True)
+        content = Path(filename).read_text(encoding='utf-8')
+        assert 'some text ' in content
+        assert ' more text' in content
+
+    def test_should_not_indent_when_pretty_print_disabled(
+        self, tmp_path: Path
+    ):
+        root = etree.fromstring(
+            b'<TEI><teiHeader><title>My Title</title></teiHeader></TEI>'
+        )
+        filename = str(tmp_path / 'output.xml')
+        serialize_xml_to_file(root, filename, pretty_print=False)
+        content = Path(filename).read_text(encoding='utf-8')
+        assert '\n' not in content
+
+
 class TestScienceBeamParser:
     class TestStartup:
         def test_should_not_preload_if_disabled(
@@ -254,6 +292,55 @@ class TestScienceBeamParser:
                 last_page=None
             )
             assert result_file == str(expected_output_path)
+
+        def test_should_pretty_print_tei_xml_when_configured(
+            self,
+            app_config: AppConfig,
+            get_tei_for_semantic_document_mock: MagicMock,
+            request_temp_path: Path
+        ):
+            parser = ScienceBeamParser.from_config(
+                AppConfig({**app_config.props, 'output': {'pretty_print_xml': True}})
+            )
+            expected_pdf_path = request_temp_path / 'test.pdf'
+            (request_temp_path / TEMP_ALTO_XML_FILENAME).write_bytes(XML_CONTENT_1)
+            get_tei_for_semantic_document_mock.return_value = TeiDocument(
+                etree.fromstring(
+                    b'<TEI><teiHeader><title>My Title</title></teiHeader></TEI>'
+                )
+            )
+            with parser.get_new_session() as session:
+                result_file = (
+                    session.get_source(str(expected_pdf_path), MediaTypes.PDF)
+                    .get_local_file_for_response_media_type(MediaTypes.TEI_XML)
+                )
+            content = Path(result_file).read_text(encoding='utf-8')
+            assert '\n' in content
+            assert 'My Title' in content
+
+        def test_should_not_pretty_print_tei_xml_when_disabled(
+            self,
+            app_config: AppConfig,
+            get_tei_for_semantic_document_mock: MagicMock,
+            request_temp_path: Path
+        ):
+            parser = ScienceBeamParser.from_config(
+                AppConfig({**app_config.props, 'output': {'pretty_print_xml': False}})
+            )
+            expected_pdf_path = request_temp_path / 'test.pdf'
+            (request_temp_path / TEMP_ALTO_XML_FILENAME).write_bytes(XML_CONTENT_1)
+            get_tei_for_semantic_document_mock.return_value = TeiDocument(
+                etree.fromstring(
+                    b'<TEI><teiHeader><title>My Title</title></teiHeader></TEI>'
+                )
+            )
+            with parser.get_new_session() as session:
+                result_file = (
+                    session.get_source(str(expected_pdf_path), MediaTypes.PDF)
+                    .get_local_file_for_response_media_type(MediaTypes.TEI_XML)
+                )
+            content = Path(result_file).read_text(encoding='utf-8')
+            assert '\n' not in content
 
         def test_should_not_convert_pdf_to_tei_xml(
             self,


### PR DESCRIPTION
Uses lxml's etree.indent() (rather than write(pretty_print=True)) so that indentation is only inserted where text/tail is absent, leaving mixed-content elements such as inline references untouched.

Enabled by default via output.pretty_print_xml in config; can be disabled by setting the flag to false or via the SCIENCEBEAM_PARSER__OUTPUT__PRETTY_PRINT_XML env var.