### PR TITLE
Add small, medium, large sampling modes between smoke and full

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: 'smoke (10 docs) or full (158 docs)'
+        description: 'smoke (10), small (25), medium (50), large (100), or full (all) docs per corpus'
         required: false
         default: 'smoke'
         type: choice
-        options: [smoke, full]
+        options: [smoke, small, medium, large, full]
   push:
     branches: [main]
   pull_request:
@@ -24,6 +24,9 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'benchmark:smoke') ||
+      contains(github.event.pull_request.labels.*.name, 'benchmark:small') ||
+      contains(github.event.pull_request.labels.*.name, 'benchmark:medium') ||
+      contains(github.event.pull_request.labels.*.name, 'benchmark:large') ||
       contains(github.event.pull_request.labels.*.name, 'benchmark:full')
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -37,8 +40,13 @@ jobs:
       BENCHMARK_SPLIT: validation
       BENCHMARK_MODE: >-
         ${{
-          contains(github.event.pull_request.labels.*.name, 'benchmark:full')
-          && 'full' || inputs.mode || 'smoke'
+          contains(github.event.pull_request.labels.*.name, 'benchmark:full') && 'full' ||
+          contains(github.event.pull_request.labels.*.name, 'benchmark:large') && 'large' ||
+          contains(github.event.pull_request.labels.*.name, 'benchmark:medium') && 'medium' ||
+          contains(github.event.pull_request.labels.*.name, 'benchmark:small') && 'small' ||
+          inputs.mode ||
+          github.ref == 'refs/heads/main' && 'medium' ||
+          'smoke'
         }}
       BENCHMARK_RUN: benchmarks/runs/${{ github.sha }}
       BASELINE_DIR: benchmarks/runs/baseline

--- a/benchmarks/eval.yml
+++ b/benchmarks/eval.yml
@@ -63,6 +63,27 @@ sampling:
     scielo_br: 10
     scielo_mx: 10
     scielo_preprints-jats: 10
+  small:
+    biorxiv: 25
+    ore: 25
+    pkp: 25
+    scielo_br: 25
+    scielo_mx: 25
+    scielo_preprints-jats: 25
+  medium:
+    biorxiv: 50
+    ore: 50
+    pkp: 50
+    scielo_br: 50
+    scielo_mx: 50
+    scielo_preprints-jats: 50
+  large:
+    biorxiv: 100
+    ore: 100
+    pkp: 100
+    scielo_br: 100
+    scielo_mx: 100
+    scielo_preprints-jats: 100
   full:
     biorxiv: 158
     ore: 199

--- a/benchmarks/predict.py
+++ b/benchmarks/predict.py
@@ -130,7 +130,10 @@ def main(argv: Optional[List[str]] = None) -> None:
         description="Predict: run parser on each PDF and save JATS XML"
     )
     parser.add_argument("--config", default="benchmarks/eval.yml")
-    parser.add_argument("--mode", choices=["smoke", "full"], default="smoke")
+    parser.add_argument(
+        "--mode", default="smoke",
+        help="Sampling mode defined in eval.yml (e.g. smoke, small, medium, large, full)"
+    )
     parser.add_argument(
         "--split", default="train", help="Dataset split: train (local) or validation (CI)"
     )

--- a/benchmarks/run_local.py
+++ b/benchmarks/run_local.py
@@ -153,7 +153,10 @@ def main(argv=None) -> None:
         description="Run benchmark locally with baseline comparison"
     )
     parser.add_argument("--config", default="benchmarks/eval.yml")
-    parser.add_argument("--mode", choices=["smoke", "full"], default="smoke")
+    parser.add_argument(
+        "--mode", default="smoke",
+        help="Sampling mode defined in eval.yml (e.g. smoke, small, medium, large, full)"
+    )
     parser.add_argument("--split", default="train", help="Dataset split (default: train)")
     parser.add_argument("--data", default="benchmarks/data")
     parser.add_argument(


### PR DESCRIPTION
related to https://github.com/eLifePathways/ScienceBeam2.0/issues/69

Adds three intermediate benchmark tiers (25, 50, 100 docs/corpus) so there are meaningful steps between the quick sanity check and the full evaluation. Mode is now an open string validated against eval.yml rather than a hard-coded choices list. Main branch CI runs use medium (50 docs) instead of smoke; PRs can opt in to any tier via benchmark:<mode> labels.