### PR TITLE
Add model configuration profile system

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -140,15 +140,16 @@ jobs:
           SPLIT: ${{ env.BENCHMARK_SPLIT }}
           MODE: ${{ env.BENCHMARK_MODE }}
         run: |
-          python3 -c "import yaml; c=yaml.safe_load(open('benchmarks/eval.yml')); [print(b['tool']+'='+b['version']) for b in c.get('baselines', [])]" \
-          | while IFS== read -r TOOL VERSION; do
+          python3 -c "import yaml; c=yaml.safe_load(open('benchmarks/eval.yml')); [print(b['tool']+' '+b['version']+' '+b.get('profile','default')) for b in c.get('baselines', [])]" \
+          | while read -r TOOL VERSION PROFILE; do
             [ -z "$TOOL" ] && continue
-            echo "=== Baseline ${TOOL}/${VERSION} ==="
+            LOCAL_DIR="benchmarks/runs/baseline-${TOOL}-${PROFILE}"
+            echo "=== Baseline ${TOOL}/${VERSION} profile=${PROFILE} ==="
             EXPECTED=$(python3 -c "import yaml; c=yaml.safe_load(open('benchmarks/eval.yml')); print(sum(c.get('sampling',{}).get('${MODE}',{}).values()))")
-            EXISTING=$(git -C sciencebeam-eval-predictions ls-tree -r --name-only HEAD "${TOOL}/${VERSION}/" 2>/dev/null | grep '\.tei\.xml$' | wc -l)
+            EXISTING=$(git -C sciencebeam-eval-predictions ls-tree -r --name-only HEAD "${TOOL}/${VERSION}/${PROFILE}/" 2>/dev/null | grep '\.tei\.xml$' | wc -l)
             echo "Predictions: ${EXISTING}/${EXPECTED}"
             if [ "$EXISTING" -lt "$EXPECTED" ]; then
-              echo "Generating predictions for ${TOOL}/${VERSION}..."
+              echo "Generating predictions for ${TOOL}/${VERSION} profile=${PROFILE}..."
               if [ "$TOOL" = "grobid" ]; then
                 IMAGE="grobid/grobid:${VERSION}"; PORT="8070:8070"
                 URL="http://localhost:8070"; HEALTH="/api/isalive"
@@ -156,7 +157,11 @@ jobs:
                 IMAGE="ghcr.io/elifepathways/sciencebeam-parser:${VERSION}"; PORT="8080:8070"
                 URL="http://localhost:8080"; HEALTH="/"
               fi
-              docker run -d --name baseline-container -p "${PORT}" "${IMAGE}"
+              CONTAINER_ENV=()
+              if [ "$TOOL" != "grobid" ] && [ "$PROFILE" != "default" ]; then
+                CONTAINER_ENV=(-e "SCIENCEBEAM_PARSER__PROFILE=${PROFILE}")
+              fi
+              docker run -d --name baseline-container -p "${PORT}" "${CONTAINER_ENV[@]}" "${IMAGE}"
               for i in $(seq 1 60); do
                 if curl -sf "${URL}${HEALTH}"; then echo; echo "Ready"; break; fi
                 [ "$i" = "60" ] && { docker logs baseline-container >&2; echo "Never ready" >&2; exit 1; }
@@ -166,12 +171,13 @@ jobs:
                 --config benchmarks/eval.yml \
                 --mode "${MODE}" --split "${SPLIT}" \
                 --data benchmarks/data \
-                --out "benchmarks/runs/baseline-${TOOL}" \
+                --out "${LOCAL_DIR}" \
                 --parser-url "${URL}" \
-                --parser-image "${TOOL}:${VERSION}"
+                --parser-image "${TOOL}:${VERSION}" \
+                --profile "${PROFILE}"
               docker stop baseline-container || true
-              DEST_BASE="sciencebeam-eval-predictions/${TOOL}/${VERSION}"
-              for CORPUS_DIR in "benchmarks/runs/baseline-${TOOL}/predictions"/*/; do
+              DEST_BASE="sciencebeam-eval-predictions/${TOOL}/${VERSION}/${PROFILE}"
+              for CORPUS_DIR in "${LOCAL_DIR}/predictions"/*/; do
                 [ -d "${CORPUS_DIR}" ] || continue
                 CORPUS=$(basename "${CORPUS_DIR}")
                 VARIANT=$(python3 -c "import yaml; c=yaml.safe_load(open('benchmarks/eval.yml')); print(c['dataset']['splits'].get('${SPLIT}',{}).get('${CORPUS}',{}).get('variant','v1'))")
@@ -179,30 +185,30 @@ jobs:
                 cp -r "${CORPUS_DIR}/." "${DEST_BASE}/${CORPUS}/${VARIANT}/${SPLIT}/"
               done
               mkdir -p "${DEST_BASE}/${SPLIT}"
-              [ -f "benchmarks/runs/baseline-${TOOL}/predictions/manifest.jsonl" ] \
-                && cp "benchmarks/runs/baseline-${TOOL}/predictions/manifest.jsonl" "${DEST_BASE}/${SPLIT}/"
+              [ -f "${LOCAL_DIR}/predictions/manifest.jsonl" ] \
+                && cp "${LOCAL_DIR}/predictions/manifest.jsonl" "${DEST_BASE}/${SPLIT}/"
               DATE=$(date --utc +%Y-%m-%dT%H:%M:%SZ)
-              echo "{\"tool\":\"${TOOL}\",\"version\":\"${VERSION}\",\"split\":\"${SPLIT}\",\"mode\":\"${MODE}\",\"generated_at\":\"${DATE}\"}" \
+              echo "{\"tool\":\"${TOOL}\",\"version\":\"${VERSION}\",\"profile\":\"${PROFILE}\",\"split\":\"${SPLIT}\",\"mode\":\"${MODE}\",\"generated_at\":\"${DATE}\"}" \
                 | python3 -m json.tool > "${DEST_BASE}/${SPLIT}/metadata.json"
               cd sciencebeam-eval-predictions
               git config user.name "github-actions[bot]"
               git config user.email "github-actions[bot]@users.noreply.github.com"
               git add --sparse .
               if ! git diff --cached --quiet; then
-                git commit -m "Add ${TOOL}/${VERSION} ${SPLIT} predictions (${MODE})"
+                git commit -m "Add ${TOOL}/${VERSION}/${PROFILE} ${SPLIT} predictions (${MODE})"
                 git push
               fi
               cd ..
             else
-              echo "Fetching predictions for ${TOOL}/${VERSION} from repo..."
-              git -C sciencebeam-eval-predictions sparse-checkout add "${TOOL}/${VERSION}"
+              echo "Fetching predictions for ${TOOL}/${VERSION} profile=${PROFILE} from repo..."
+              git -C sciencebeam-eval-predictions sparse-checkout add "${TOOL}/${VERSION}/${PROFILE}"
               git -C sciencebeam-eval-predictions checkout
               for CORPUS in $(python3 -c "import yaml; c=yaml.safe_load(open('benchmarks/eval.yml')); print(' '.join(c['dataset']['splits'].get('${SPLIT}', {}).keys()))"); do
                 VARIANT=$(python3 -c "import yaml; c=yaml.safe_load(open('benchmarks/eval.yml')); print(c['dataset']['splits'].get('${SPLIT}',{}).get('${CORPUS}',{}).get('variant','v1'))")
-                SRC="sciencebeam-eval-predictions/${TOOL}/${VERSION}/${CORPUS}/${VARIANT}/${SPLIT}"
+                SRC="sciencebeam-eval-predictions/${TOOL}/${VERSION}/${PROFILE}/${CORPUS}/${VARIANT}/${SPLIT}"
                 if [ -d "${SRC}" ]; then
-                  mkdir -p "benchmarks/runs/baseline-${TOOL}/predictions/${CORPUS}"
-                  cp -r "${SRC}/." "benchmarks/runs/baseline-${TOOL}/predictions/${CORPUS}/"
+                  mkdir -p "${LOCAL_DIR}/predictions/${CORPUS}"
+                  cp -r "${SRC}/." "${LOCAL_DIR}/predictions/${CORPUS}/"
                 fi
               done
             fi
@@ -248,10 +254,10 @@ jobs:
 
       - name: Score baseline predictions
         run: |
-          python3 -c "import yaml; c=yaml.safe_load(open('benchmarks/eval.yml')); [print(b['tool']+'='+b['version']) for b in c.get('baselines', [])]" \
-          | while IFS== read -r TOOL VERSION; do
+          python3 -c "import yaml; c=yaml.safe_load(open('benchmarks/eval.yml')); [print(b['tool']+' '+b['version']+' '+b.get('profile','default')) for b in c.get('baselines', [])]" \
+          | while read -r TOOL VERSION PROFILE; do
             [ -z "$TOOL" ] && continue
-            RUN_DIR="benchmarks/runs/baseline-${TOOL}"
+            RUN_DIR="benchmarks/runs/baseline-${TOOL}-${PROFILE}"
             if [ -d "${RUN_DIR}/predictions" ]; then
               uv run python -m benchmarks.score \
                 --config benchmarks/eval.yml \
@@ -259,7 +265,7 @@ jobs:
                 --split "${{ env.BENCHMARK_SPLIT }}" \
                 --data benchmarks/data
             else
-              echo "No predictions for ${TOOL}/${VERSION}, skipping"
+              echo "No predictions for ${TOOL}/${VERSION} profile=${PROFILE}, skipping"
             fi
           done
 
@@ -270,7 +276,9 @@ jobs:
           SPLIT: ${{ env.BENCHMARK_SPLIT }}
           MODE: ${{ env.BENCHMARK_MODE }}
         run: |
-          DEST_BASE="sciencebeam-eval-predictions/sciencebeam-parser/main"
+          PROFILE="${{ env.BENCHMARK_PROFILE }}"
+          [ -z "$PROFILE" ] && PROFILE="default"
+          DEST_BASE="sciencebeam-eval-predictions/sciencebeam-parser/main/${PROFILE}"
           PREDICTIONS_SRC="${{ env.BENCHMARK_RUN }}/predictions"
           for CORPUS_DIR in "${PREDICTIONS_SRC}"/*/; do
             [ -d "${CORPUS_DIR}" ] || continue
@@ -282,14 +290,14 @@ jobs:
           mkdir -p "${DEST_BASE}/${SPLIT}"
           [ -f "${PREDICTIONS_SRC}/manifest.jsonl" ] && cp "${PREDICTIONS_SRC}/manifest.jsonl" "${DEST_BASE}/${SPLIT}/"
           DATE=$(date --utc +%Y-%m-%dT%H:%M:%SZ)
-          echo "{\"tool\":\"sciencebeam-parser\",\"version\":\"main\",\"image\":\"${IMAGE_TAG}\",\"split\":\"${SPLIT}\",\"mode\":\"${MODE}\",\"generated_at\":\"${DATE}\"}" \
+          echo "{\"tool\":\"sciencebeam-parser\",\"version\":\"main\",\"profile\":\"${PROFILE}\",\"image\":\"${IMAGE_TAG}\",\"split\":\"${SPLIT}\",\"mode\":\"${MODE}\",\"generated_at\":\"${DATE}\"}" \
             | python3 -m json.tool > "${DEST_BASE}/${SPLIT}/metadata.json"
           cd sciencebeam-eval-predictions
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add --sparse .
           if ! git diff --cached --quiet; then
-            git commit -m "Update sciencebeam-parser/main ${SPLIT} predictions (${IMAGE_TAG})"
+            git commit -m "Update sciencebeam-parser/main/${PROFILE} ${SPLIT} predictions (${IMAGE_TAG})"
             git push
           fi
 
@@ -303,11 +311,11 @@ jobs:
       - name: Generate comparison report
         run: |
           SUMMARY_ARGS=()
-          while IFS== read -r TOOL VERSION; do
+          while read -r TOOL VERSION PROFILE; do
             [ -z "$TOOL" ] && continue
-            SUMMARY_PATH="benchmarks/runs/baseline-${TOOL}/summary.json"
-            [ -f "${SUMMARY_PATH}" ] && SUMMARY_ARGS+=("--summary" "${TOOL} ${VERSION}=${SUMMARY_PATH}")
-          done < <(python3 -c "import yaml; c=yaml.safe_load(open('benchmarks/eval.yml')); [print(b['tool']+'='+b['version']) for b in c.get('baselines', [])]")
+            SUMMARY_PATH="benchmarks/runs/baseline-${TOOL}-${PROFILE}/summary.json"
+            [ -f "${SUMMARY_PATH}" ] && SUMMARY_ARGS+=("--summary" "${TOOL} ${VERSION} (${PROFILE})=${SUMMARY_PATH}")
+          done < <(python3 -c "import yaml; c=yaml.safe_load(open('benchmarks/eval.yml')); [print(b['tool']+' '+b['version']+' '+b.get('profile','default')) for b in c.get('baselines', [])]")
           if [ -f "${{ env.BASELINE_DIR }}/summary.json" ]; then
             BASELINE_LABEL=$(cat "${{ env.BASELINE_DIR }}/label.txt" 2>/dev/null || echo "baseline")
             SUMMARY_ARGS+=("--summary" "${BASELINE_LABEL}=${{ env.BASELINE_DIR }}/summary.json")

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,6 +9,11 @@ on:
         default: 'smoke'
         type: choice
         options: [smoke, small, medium, large, full]
+      profile:
+        description: 'Model configuration profile (empty = image default)'
+        required: false
+        default: ''
+        type: string
   push:
     branches: [main]
   pull_request:
@@ -47,6 +52,13 @@ jobs:
           inputs.mode ||
           github.ref == 'refs/heads/main' && 'medium' ||
           'smoke'
+        }}
+      BENCHMARK_PROFILE: >-
+        ${{
+          contains(github.event.pull_request.labels.*.name, 'profile:grobid_crf') && 'grobid_crf' ||
+          contains(github.event.pull_request.labels.*.name, 'profile:biorxiv_elife') && 'biorxiv_elife' ||
+          inputs.profile ||
+          ''
         }}
       BENCHMARK_RUN: benchmarks/runs/${{ github.sha }}
       BASELINE_DIR: benchmarks/runs/baseline
@@ -197,7 +209,13 @@ jobs:
           done
 
       - name: Start sciencebeam-parser
-        run: docker run -d --name sciencebeam-parser -p 8080:8070 ${{ steps.image_tag.outputs.value }}
+        run: |
+          PROFILE_ENV=()
+          if [ -n "${{ env.BENCHMARK_PROFILE }}" ]; then
+            PROFILE_ENV=(-e "SCIENCEBEAM_PARSER__PROFILE=${{ env.BENCHMARK_PROFILE }}")
+          fi
+          docker run -d --name sciencebeam-parser -p 8080:8070 \
+            "${PROFILE_ENV[@]}" ${{ steps.image_tag.outputs.value }}
 
       - name: Wait for parser
         run: |
@@ -214,6 +232,10 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
+          PROFILE_ARG=()
+          if [ -n "${{ env.BENCHMARK_PROFILE }}" ]; then
+            PROFILE_ARG=(--profile "${{ env.BENCHMARK_PROFILE }}")
+          fi
           uv run python -m benchmarks.predict \
             --config benchmarks/eval.yml \
             --mode ${{ env.BENCHMARK_MODE }} \
@@ -221,7 +243,8 @@ jobs:
             --data benchmarks/data \
             --out ${{ env.BENCHMARK_RUN }} \
             --parser-url http://localhost:8080 \
-            --parser-image "${{ steps.image_tag.outputs.value }}"
+            --parser-image "${{ steps.image_tag.outputs.value }}" \
+            "${PROFILE_ARG[@]}"
 
       - name: Score baseline predictions
         run: |

--- a/benchmarks/predict.py
+++ b/benchmarks/predict.py
@@ -70,7 +70,7 @@ def run_predict(  # pylint: disable=too-many-locals
     run_dir: Path,
     parser_url: str,
     parser_image: Optional[str],
-    parser_config: Optional[str],
+    profile: Optional[str],
 ) -> None:
     records = fetch_data(config, mode, split, data_dir)
     done = _load_done(run_dir)
@@ -110,7 +110,7 @@ def run_predict(  # pylint: disable=too-many-locals
     run_dir.mkdir(parents=True, exist_ok=True)
     (run_dir / "run.json").write_text(json.dumps({
         "parser_image": parser_image,
-        "parser_config": parser_config,
+        "profile": profile,
         "dataset_repo_id": config["dataset"]["repo_id"],
         "dataset_revision": config["dataset"]["revision"],
         "split": split,
@@ -142,7 +142,7 @@ def main(argv: Optional[List[str]] = None) -> None:
     parser.add_argument("--parser-url", default="http://localhost:8080")
     parser.add_argument("--parser-image", default=None, help="Docker image tag (provenance only)")
     parser.add_argument(
-        "--parser-config", default=None, help="Parser config override path (provenance only)"
+        "--profile", default=None, help="Model configuration profile name"
     )
     args = parser.parse_args(argv)
 
@@ -159,7 +159,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         run_dir=Path(args.out),
         parser_url=args.parser_url,
         parser_image=args.parser_image,
-        parser_config=args.parser_config,
+        profile=args.profile,
     )
 
 

--- a/benchmarks/run_local.py
+++ b/benchmarks/run_local.py
@@ -60,14 +60,24 @@ def _wait_healthy(url: str, health_path: str, retries: int = 60, interval: int =
     )
 
 
-def _docker_start(name: str, image: str, port: str) -> None:
+def _docker_start(name: str, image: str, port: str, env_vars: Optional[dict] = None) -> None:
     LOGGER.info("Starting container %s (%s)", name, image)
-    subprocess.run(["docker", "run", "-d", "--name", name, "-p", port, image], check=True)
+    cmd = ["docker", "run", "-d", "--name", name, "-p", port]
+    for k, v in (env_vars or {}).items():
+        cmd += ["-e", f"{k}={v}"]
+    cmd.append(image)
+    subprocess.run(cmd, check=True)
 
 
 def _docker_stop(name: str) -> None:
     subprocess.run(["docker", "stop", name], check=False, capture_output=True)
     subprocess.run(["docker", "rm", name], check=False, capture_output=True)
+
+
+def _baseline_env_vars(tool: str, profile: Optional[str]) -> dict:
+    if profile and tool != "grobid":
+        return {"SCIENCEBEAM_PARSER__PROFILE": profile}
+    return {}
 
 
 def _run_baseline(
@@ -78,22 +88,26 @@ def _run_baseline(
     runs_dir: Path,
     tool: str,
     version: str,
+    profile: Optional[str],
     expected: int,
 ) -> Optional[Tuple[str, Path]]:
-    run_dir = runs_dir / "baselines" / tool / version / split
+    run_dir = runs_dir / "baselines" / tool / version / (profile or "default") / split
     existing = _count_predictions(run_dir)
-    LOGGER.info("=== Baseline %s/%s: %d/%d predictions ===", tool, version, existing, expected)
+    LOGGER.info(
+        "=== Baseline %s/%s (profile=%s): %d/%d predictions ===",
+        tool, version, profile or "default", existing, expected,
+    )
 
     if existing < expected:
         dcfg = _tool_docker_config(tool, version)
         container = f"run-local-{tool}"
         _docker_stop(container)
-        _docker_start(container, dcfg["image"], dcfg["port"])
+        _docker_start(container, dcfg["image"], dcfg["port"], _baseline_env_vars(tool, profile))
         try:
             _wait_healthy(dcfg["url"], dcfg["health_path"])
             run_predict(
                 config, mode, split, data_dir, run_dir,
-                dcfg["url"], f"{tool}:{version}", None,
+                dcfg["url"], f"{tool}:{version}", profile,
             )
         finally:
             _docker_stop(container)
@@ -102,8 +116,9 @@ def _run_baseline(
 
     run_score(config, run_dir, data_dir, out_path=None, split_override=split)
 
+    label = f"{tool} {version}" + (f" ({profile})" if profile else "")
     summary_path = run_dir / "summary.json"
-    return (f"{tool} {version}", summary_path) if summary_path.exists() else None
+    return (label, summary_path) if summary_path.exists() else None
 
 
 def run_local(
@@ -114,6 +129,7 @@ def run_local(
     runs_dir: Path,
     parser_url: Optional[str],
     parser_image: Optional[str],
+    parser_profile: Optional[str],
     baseline_only: bool,
 ) -> None:
     expected = _expected_count(config, mode)
@@ -122,7 +138,8 @@ def run_local(
     for baseline in config.get("baselines", []):
         entry = _run_baseline(
             config, mode, split, data_dir, runs_dir,
-            baseline["tool"], baseline["version"], expected,
+            baseline["tool"], baseline["version"],
+            baseline.get("profile"), expected,
         )
         if entry:
             labeled_paths.append(entry)
@@ -135,15 +152,15 @@ def run_local(
         return
 
     primary_run_dir = runs_dir / split
-    run_predict(config, mode, split, data_dir, primary_run_dir, parser_url, parser_image, None)
+    run_predict(
+        config, mode, split, data_dir, primary_run_dir, parser_url, parser_image, parser_profile
+    )
     run_score(config, primary_run_dir, data_dir, out_path=None, split_override=split)
 
-    primary_label = parser_image or "local"
-    labeled_paths.append((primary_label, primary_run_dir / "summary.json"))
+    labeled_paths.append((parser_image or "local", primary_run_dir / "summary.json"))
 
     if len(labeled_paths) >= 2:
-        report_path = primary_run_dir / "comparison.md"
-        run_compare(labeled_paths, report_path)
+        run_compare(labeled_paths, primary_run_dir / "comparison.md")
     else:
         LOGGER.info("Only one summary available; skipping comparison report")
 
@@ -170,6 +187,9 @@ def main(argv=None) -> None:
         "--parser-image", default=None, help="Primary parser image tag (provenance label)"
     )
     parser.add_argument(
+        "--profile", default=None, help="Model configuration profile for the primary parser"
+    )
+    parser.add_argument(
         "--baseline-only", action="store_true",
         help="Only generate and score baselines; skip primary parser",
     )
@@ -188,6 +208,7 @@ def main(argv=None) -> None:
         runs_dir=Path(args.runs),
         parser_url=args.parser_url,
         parser_image=args.parser_image,
+        parser_profile=args.profile,
         baseline_only=args.baseline_only,
     )
 

--- a/benchmarks/score.py
+++ b/benchmarks/score.py
@@ -158,7 +158,7 @@ def _render_report(  # pylint: disable=too-many-locals
 
     if run_record:
         image = run_record.get("parser_image") or "local"
-        cfg = run_record.get("parser_config") or "default"
+        cfg = run_record.get("profile") or run_record.get("parser_config") or "default"
         mode = run_record.get("mode", "?")
         lines += [f"**Image:** `{image}`  **Config:** `{cfg}`  **Mode:** {mode}", ""]
 

--- a/benchmarks/tests/run_local_test.py
+++ b/benchmarks/tests/run_local_test.py
@@ -94,7 +94,7 @@ class TestRunLocal:
         mock_score.side_effect = fake_score
 
         run_local(_CONFIG, "smoke", "train", tmp_path / "data", runs_dir,
-                  parser_url=None, parser_image=None, baseline_only=True)
+                  parser_url=None, parser_image=None, parser_profile=None, baseline_only=True)
 
         mock_start.assert_called_once()
         mock_predict.assert_called_once()
@@ -109,7 +109,8 @@ class TestRunLocal:
     ):
         runs_dir = tmp_path / "runs"
         pred_dir = (
-            runs_dir / "baselines" / "grobid" / "0.9.0-crf" / "train" / "predictions" / "biorxiv"
+            runs_dir / "baselines" / "grobid" / "0.9.0-crf" / "default" / "train"
+            / "predictions" / "biorxiv"
         )
         pred_dir.mkdir(parents=True)
         for i in range(10):
@@ -121,7 +122,7 @@ class TestRunLocal:
         mock_score.side_effect = fake_score
 
         run_local(_CONFIG, "smoke", "train", tmp_path / "data", runs_dir,
-                  parser_url=None, parser_image=None, baseline_only=True)
+                  parser_url=None, parser_image=None, parser_profile=None, baseline_only=True)
 
         mock_start.assert_not_called()
         mock_predict.assert_not_called()
@@ -144,7 +145,8 @@ class TestRunLocal:
         mock_score.side_effect = fake_score
 
         run_local(_CONFIG, "smoke", "train", tmp_path / "data", runs_dir,
-                  parser_url="http://localhost:8080", parser_image=None, baseline_only=True)
+                  parser_url="http://localhost:8080", parser_image=None,
+                  parser_profile=None, baseline_only=True)
 
         mock_compare.assert_not_called()
         assert mock_predict.call_count <= 1  # only baseline predict, no primary
@@ -168,10 +170,100 @@ class TestRunLocal:
 
         run_local(_CONFIG, "smoke", "train", tmp_path / "data", runs_dir,
                   parser_url="http://localhost:8080", parser_image="my-image:v1",
-                  baseline_only=False)
+                  parser_profile=None, baseline_only=False)
 
         mock_compare.assert_called_once()
         labeled_paths = mock_compare.call_args.args[0]
         labels = [label for label, _ in labeled_paths]
         assert "grobid 0.9.0-crf" in labels
         assert "my-image:v1" in labels
+
+    @patch("benchmarks.run_local._docker_stop")
+    @patch("benchmarks.run_local._docker_start")
+    @patch("benchmarks.run_local._wait_healthy")
+    @patch("benchmarks.run_local.run_score")
+    @patch("benchmarks.run_local.run_predict")
+    def test_passes_profile_env_var_to_sbp_container(
+        self, _mock_predict, mock_score, _mock_wait, mock_start, _mock_stop, tmp_path: Path
+    ):
+        config = {
+            **_CONFIG,
+            "baselines": [{"tool": "sciencebeam-parser", "version": "1.0.0",
+                           "profile": "grobid_crf_0_9_0"}],
+        }
+
+        def fake_score(_config, run_dir, _data_dir, **_kwargs):
+            self._make_summary(run_dir)
+
+        mock_score.side_effect = fake_score
+
+        run_local(config, "smoke", "train", tmp_path / "data", tmp_path / "runs",
+                  parser_url=None, parser_image=None, parser_profile=None, baseline_only=True)
+
+        call_kwargs = mock_start.call_args
+        env_vars = (
+            call_kwargs.args[3]
+            if len(call_kwargs.args) > 3
+            else call_kwargs.kwargs.get("env_vars", {})
+        )
+        assert env_vars.get("SCIENCEBEAM_PARSER__PROFILE") == "grobid_crf_0_9_0"
+
+    @patch("benchmarks.run_local._docker_stop")
+    @patch("benchmarks.run_local._docker_start")
+    @patch("benchmarks.run_local._wait_healthy")
+    @patch("benchmarks.run_local.run_score")
+    @patch("benchmarks.run_local.run_predict")
+    def test_grobid_baseline_does_not_get_profile_env_var(
+        self, _mock_predict, mock_score, _mock_wait, mock_start, _mock_stop, tmp_path: Path
+    ):
+        config = {
+            **_CONFIG,
+            "baselines": [{"tool": "grobid", "version": "0.9.0-crf",
+                           "profile": "some_profile"}],
+        }
+
+        def fake_score(_config, run_dir, _data_dir, **_kwargs):
+            self._make_summary(run_dir)
+
+        mock_score.side_effect = fake_score
+
+        run_local(config, "smoke", "train", tmp_path / "data", tmp_path / "runs",
+                  parser_url=None, parser_image=None, parser_profile=None, baseline_only=True)
+
+        call_kwargs = mock_start.call_args
+        env_vars = (
+            call_kwargs.args[3]
+            if len(call_kwargs.args) > 3
+            else call_kwargs.kwargs.get("env_vars", {})
+        )
+        assert "SCIENCEBEAM_PARSER__PROFILE" not in (env_vars or {})
+
+    @patch("benchmarks.run_local._docker_stop")
+    @patch("benchmarks.run_local._docker_start")
+    @patch("benchmarks.run_local._wait_healthy")
+    @patch("benchmarks.run_local.run_score")
+    @patch("benchmarks.run_local.run_predict")
+    def test_profile_included_in_baseline_label(
+        self, mock_predict, mock_score, _mock_wait, _mock_start, _mock_stop, tmp_path: Path
+    ):
+        config = {
+            **_CONFIG,
+            "baselines": [{"tool": "grobid", "version": "0.9.0-crf",
+                           "profile": "grobid_crf_0_9_0"}],
+        }
+        runs_dir = tmp_path / "runs"
+
+        def fake_score(_config, run_dir, _data_dir, **_kwargs):
+            self._make_summary(run_dir)
+
+        mock_score.side_effect = fake_score
+
+        run_local(config, "smoke", "train", tmp_path / "data", runs_dir,
+                  parser_url="http://localhost:8080", parser_image=None,
+                  parser_profile=None, baseline_only=False)
+
+        # run_predict is called with run_dir as the 5th positional arg;
+        # the path must contain the profile name segment
+        baseline_call = mock_predict.call_args_list[0]
+        run_dir = baseline_call.args[4]
+        assert "grobid_crf_0_9_0" in str(run_dir)

--- a/sciencebeam_parser/config/config.py
+++ b/sciencebeam_parser/config/config.py
@@ -17,6 +17,16 @@ def parse_env_value(value: str) -> Union[str, int]:
     return yaml.safe_load(value)
 
 
+def _deep_merge(base: dict, overlay: dict) -> dict:
+    result = copy.deepcopy(base)
+    for key, value in overlay.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = copy.deepcopy(value)
+    return result
+
+
 class AppConfig:
     def __init__(self, props: dict):
         self.props = props
@@ -49,6 +59,48 @@ class AppConfig:
                 parent_props = parent_props.setdefault(parent_key, {})
             parent_props[leaf_key] = parse_env_value(env_value)
         return AppConfig(updated_props)
+
+    def resolve_profile(self, profile_name: Optional[str] = None) -> 'AppConfig':
+        name = profile_name or self.props.get('profile')
+        if not name:
+            return self
+
+        aliases = self.props.get('profile_aliases', {})
+        resolved = aliases.get(name, name)
+
+        profiles = self.props.get('profiles', {})
+        if resolved not in profiles:
+            available = sorted(profiles)
+            suffix = f' (alias for {resolved!r})' if resolved != name else ''
+            raise ValueError(
+                f'Unknown profile {name!r}{suffix}. Available: {available}'
+            )
+
+        profile = profiles[resolved]
+        overlay: dict = {}
+
+        seq_name = profile.get('sequence_models')
+        if seq_name:
+            seq_profiles = self.props.get('sequence_model_profiles', {})
+            if seq_name not in seq_profiles:
+                raise ValueError(
+                    f'Profile {resolved!r} references unknown sequence_model_profile '
+                    f'{seq_name!r}. Available: {sorted(seq_profiles)}'
+                )
+            overlay['models'] = seq_profiles[seq_name]
+
+        for key, value in profile.items():
+            if key != 'sequence_models':
+                overlay[key] = value
+
+        return AppConfig(_deep_merge(self.props, overlay))
+
+    def get_active_profile_name(self, profile_name: Optional[str] = None) -> Optional[str]:
+        name = profile_name or self.props.get('profile')
+        if not name:
+            return None
+        aliases = self.props.get('profile_aliases', {})
+        return aliases.get(name, name)
 
     def get(self, key: str, default_value: Optional[Any] = None):
         return self.props.get(key, default_value)

--- a/sciencebeam_parser/resources/default_config/config.yml
+++ b/sciencebeam_parser/resources/default_config/config.yml
@@ -111,6 +111,74 @@ models:
   citation:
     path: 'https://github.com/eLifePathways/sciencebeam-models/releases/download/v0.0.1/2020-10-04-delft-grobid-citation-biorxiv-no-word-embedding.tar.gz'
 
+sequence_model_profiles:
+  biorxiv_elife:
+    segmentation:
+      path: 'https://github.com/eLifePathways/sciencebeam-models/releases/download/biorxiv-grobid/2021-05-11-delft-grobid-segmentation-biorxiv-10k-auto-v0.0.23-train-1966-e133.tar.gz'
+      use_first_token_of_block: false
+    header:
+      path: 'https://github.com/eLifePathways/sciencebeam-models/releases/download/v0.0.1/2020-10-04-delft-grobid-header-biorxiv-no-word-embedding.tar.gz'
+    name_header:
+      path: 'https://github.com/kermitt2/grobid/raw/0.6.0/grobid-home/models/name/header'
+      engine: 'wapiti'
+    name_citation:
+      path: 'https://github.com/kermitt2/grobid/raw/0.6.2/grobid-home/models/name/citation'
+      engine: 'wapiti'
+    affiliation_address:
+      path: 'https://github.com/eLifePathways/sciencebeam-models/releases/download/v0.0.1/2020-10-04-delft-grobid-affiliation-address-biorxiv-no-word-embedding.tar.gz'
+    fulltext:
+      path: 'https://github.com/eLifePathways/sciencebeam-models/releases/download/biorxiv-grobid/2021-05-11-delft-grobid-fulltext-biorxiv-10k-auto-v0.0.21-train-1986-e159.tar.gz'
+    figure:
+      path: 'https://github.com/eLifePathways/sciencebeam-models/releases/download/biorxiv-grobid/2021-05-11-delft-grobid-figure-biorxiv-10k-auto-v0.0.18-train-1865-e219.tar.gz'
+    table:
+      path: 'https://github.com/eLifePathways/sciencebeam-models/releases/download/biorxiv-grobid/2021-05-11-delft-grobid-table-biorxiv-10k-auto-v0.0.18-train-1865-e569.tar.gz'
+    reference_segmenter:
+      path: 'https://github.com/eLifePathways/sciencebeam-models/releases/download/v0.0.1/2020-10-04-delft-grobid-reference-segmenter-biorxiv-no-word-embedding.tar.gz'
+    citation:
+      path: 'https://github.com/eLifePathways/sciencebeam-models/releases/download/v0.0.1/2020-10-04-delft-grobid-citation-biorxiv-no-word-embedding.tar.gz'
+  grobid_crf_0_9_0:
+    segmentation:
+      path: 'https://github.com/kermitt2/grobid/raw/0.9.0/grobid-home/models/segmentation'
+      engine: 'wapiti'
+    header:
+      path: 'https://github.com/kermitt2/grobid/raw/0.9.0/grobid-home/models/header'
+      engine: 'wapiti'
+    name_header:
+      path: 'https://github.com/kermitt2/grobid/raw/0.9.0/grobid-home/models/name/header'
+      engine: 'wapiti'
+    name_citation:
+      path: 'https://github.com/kermitt2/grobid/raw/0.9.0/grobid-home/models/name/citation'
+      engine: 'wapiti'
+    affiliation_address:
+      path: 'https://github.com/kermitt2/grobid/raw/0.9.0/grobid-home/models/affiliations'
+      engine: 'wapiti'
+    fulltext:
+      path: 'https://github.com/kermitt2/grobid/raw/0.9.0/grobid-home/models/fulltext'
+      engine: 'wapiti'
+    figure:
+      path: 'https://github.com/kermitt2/grobid/raw/0.9.0/grobid-home/models/figure'
+      engine: 'wapiti'
+    table:
+      path: 'https://github.com/kermitt2/grobid/raw/0.9.0/grobid-home/models/table'
+      engine: 'wapiti'
+    reference_segmenter:
+      path: 'https://github.com/kermitt2/grobid/raw/0.9.0/grobid-home/models/reference-segmenter'
+      engine: 'wapiti'
+    citation:
+      path: 'https://github.com/kermitt2/grobid/raw/0.9.0/grobid-home/models/citation'
+      engine: 'wapiti'
+
+profiles:
+  biorxiv_elife:
+    sequence_models: biorxiv_elife
+  grobid_crf_0_9_0:
+    sequence_models: grobid_crf_0_9_0
+
+profile_aliases:
+  grobid_crf: grobid_crf_0_9_0
+
+profile: biorxiv_elife
+
 cv_models:
   default:
     path: 'lp://efficientdet/PubLayNet'

--- a/sciencebeam_parser/resources/default_config/config.yml
+++ b/sciencebeam_parser/resources/default_config/config.yml
@@ -150,7 +150,7 @@ sequence_model_profiles:
       path: 'https://github.com/kermitt2/grobid/raw/0.9.0/grobid-home/models/name/citation'
       engine: 'wapiti'
     affiliation_address:
-      path: 'https://github.com/kermitt2/grobid/raw/0.9.0/grobid-home/models/affiliations'
+      path: 'https://github.com/kermitt2/grobid/raw/0.9.0/grobid-home/models/affiliation-address'
       engine: 'wapiti'
     fulltext:
       path: 'https://github.com/kermitt2/grobid/raw/0.9.0/grobid-home/models/fulltext'

--- a/sciencebeam_parser/service/server.py
+++ b/sciencebeam_parser/service/server.py
@@ -38,7 +38,12 @@ def create_app_for_config(config: AppConfig) -> FastAPI:
 
 
 def get_app_config() -> AppConfig:
-    return AppConfig.load_yaml(DEFAULT_CONFIG_FILE).apply_environment_variables()
+    profile_name = os.environ.get('SCIENCEBEAM_PARSER__PROFILE')
+    return (
+        AppConfig.load_yaml(DEFAULT_CONFIG_FILE)
+        .resolve_profile(profile_name)
+        .apply_environment_variables()
+    )
 
 
 def apply_logging_config(logging_config: Optional[dict] = None):

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -1,11 +1,144 @@
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Optional
 from unittest.mock import patch
 
 import pytest
 import yaml
 
-from sciencebeam_parser.config.config import AppConfig
+from sciencebeam_parser.config.config import AppConfig, _deep_merge
+
+
+MINIMAL_PROFILE_CONFIG = {
+    'sequence_model_profiles': {
+        'profile_a': {
+            'segmentation': {'path': 'path_a/segmentation'},
+            'header': {'path': 'path_a/header'},
+        },
+        'profile_b': {
+            'segmentation': {'path': 'path_b/segmentation', 'engine': 'wapiti'},
+            'header': {'path': 'path_b/header', 'engine': 'wapiti'},
+        },
+    },
+    'profiles': {
+        'profile_a': {'sequence_models': 'profile_a'},
+        'profile_b': {'sequence_models': 'profile_b'},
+        'profile_with_extra': {
+            'sequence_models': 'profile_a',
+            'processors': {'fulltext': {'use_cv_model': True}},
+        },
+    },
+    'profile_aliases': {
+        'alias_a': 'profile_a',
+    },
+    'profile': 'profile_a',
+    'models': {
+        'segmentation': {'path': 'base/segmentation', 'use_first_token_of_block': False},
+        'header': {'path': 'base/header'},
+    },
+}
+
+
+class TestDeepMerge:
+    def test_scalar_overlay_wins(self):
+        result = _deep_merge({'a': 1}, {'a': 2})
+        assert result['a'] == 2
+
+    def test_base_key_preserved_when_not_in_overlay(self):
+        result = _deep_merge({'a': 1, 'b': 2}, {'a': 99})
+        assert result['b'] == 2
+
+    def test_nested_dict_merged_recursively(self):
+        base = {'models': {'segmentation': {'path': 'old', 'use_first_token_of_block': False}}}
+        overlay = {'models': {'segmentation': {'path': 'new'}}}
+        result = _deep_merge(base, overlay)
+        assert result['models']['segmentation']['path'] == 'new'
+        assert result['models']['segmentation']['use_first_token_of_block'] is False
+
+    def test_overlay_adds_new_nested_key(self):
+        base = {'models': {'segmentation': {'path': 'old'}}}
+        overlay = {'models': {'header': {'path': 'new_header'}}}
+        result = _deep_merge(base, overlay)
+        assert result['models']['segmentation']['path'] == 'old'
+        assert result['models']['header']['path'] == 'new_header'
+
+    def test_does_not_mutate_base(self):
+        base = {'a': {'b': 1}}
+        _deep_merge(base, {'a': {'b': 2}})
+        assert base['a']['b'] == 1
+
+
+class TestAppConfigResolveProfile:
+    def _make_config(self, extra: Optional[dict] = None) -> AppConfig:
+        props = dict(MINIMAL_PROFILE_CONFIG)
+        if extra:
+            props = {**props, **extra}
+        return AppConfig(props)
+
+    def test_applies_sequence_model_profile(self):
+        config = self._make_config().resolve_profile('profile_b')
+        assert config['models']['segmentation']['path'] == 'path_b/segmentation'
+        assert config['models']['segmentation']['engine'] == 'wapiti'
+        assert config['models']['header']['path'] == 'path_b/header'
+
+    def test_inherits_base_model_keys_not_in_profile(self):
+        config = self._make_config().resolve_profile('profile_a')
+        assert config['models']['segmentation']['path'] == 'path_a/segmentation'
+        assert config['models']['segmentation']['use_first_token_of_block'] is False
+
+    def test_uses_default_profile_when_no_name_given(self):
+        config = self._make_config().resolve_profile()
+        assert config['models']['segmentation']['path'] == 'path_a/segmentation'
+
+    def test_resolves_alias(self):
+        config = self._make_config().resolve_profile('alias_a')
+        assert config['models']['segmentation']['path'] == 'path_a/segmentation'
+
+    def test_profile_with_extra_config_section(self):
+        config = self._make_config().resolve_profile('profile_with_extra')
+        assert config['models']['segmentation']['path'] == 'path_a/segmentation'
+        assert config['processors']['fulltext']['use_cv_model'] is True
+
+    def test_returns_self_when_no_profile_configured(self):
+        props = {k: v for k, v in MINIMAL_PROFILE_CONFIG.items() if k != 'profile'}
+        config = AppConfig(props)
+        result = config.resolve_profile()
+        assert result is config
+
+    def test_raises_on_unknown_profile(self):
+        config = self._make_config()
+        with pytest.raises(ValueError, match='Unknown profile'):
+            config.resolve_profile('nonexistent')
+
+    def test_raises_on_unknown_alias_target(self):
+        props = {
+            **MINIMAL_PROFILE_CONFIG,
+            'profile_aliases': {'broken_alias': 'does_not_exist'},
+        }
+        config = AppConfig(props)
+        with pytest.raises(ValueError, match="alias for 'does_not_exist'"):
+            config.resolve_profile('broken_alias')
+
+    def test_raises_on_unknown_sequence_model_profile(self):
+        props = {
+            **MINIMAL_PROFILE_CONFIG,
+            'profiles': {'bad': {'sequence_models': 'missing_seq_profile'}},
+        }
+        config = AppConfig(props)
+        with pytest.raises(ValueError, match='sequence_model_profile'):
+            config.resolve_profile('bad')
+
+    def test_get_active_profile_name_with_explicit_name(self):
+        config = self._make_config()
+        assert config.get_active_profile_name('alias_a') == 'profile_a'
+
+    def test_get_active_profile_name_from_default(self):
+        config = self._make_config()
+        assert config.get_active_profile_name() == 'profile_a'
+
+    def test_get_active_profile_name_returns_none_when_not_configured(self):
+        props = {k: v for k, v in MINIMAL_PROFILE_CONFIG.items() if k != 'profile'}
+        config = AppConfig(props)
+        assert config.get_active_profile_name() is None
 
 
 @pytest.fixture(name='env_vars_mock')


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/87

Introduce named profiles to manage sets of model weights without
editing config.yml for each switch. A profile selects a
sequence_model_profile (model paths/engines) and can override any
other config section; aliases provide stable "current version"
pointers (e.g. grobid_crf → grobid_crf_0_9_0).

Resolution order: base config → active profile overlay → individual
env var overrides (SCIENCEBEAM_PARSER__MODELS__*). The active profile
is set via `profile:` in config.yml or SCIENCEBEAM_PARSER__PROFILE env
var.

Two initial profiles: biorxiv_elife (current default, eLife-trained
delft models) and grobid_crf_0_9_0 (placeholder URLs — real 0.9.0
paths to be filled in). Benchmark tooling records the profile in
run.json and uses it as a path segment in baseline run directories,
enabling predictions for the same image with different model sets to
coexist.