### PR TITLE
Export per-document score JSON alongside other example files

### DIFF
--- a/benchmarks/show_cases.py
+++ b/benchmarks/show_cases.py
@@ -220,6 +220,14 @@ def _export_case(
         run_b / "predictions" / corpus / f"{record_id}.tei.xml",
         out_dir / f"{record_id}.run-b.tei.xml",
     )
+    _copy_if_exists(
+        run_a / "scores" / corpus / f"{record_id}.json",
+        out_dir / f"{record_id}.run-a.scores.json",
+    )
+    _copy_if_exists(
+        run_b / "scores" / corpus / f"{record_id}.json",
+        out_dir / f"{record_id}.run-b.scores.json",
+    )
 
 
 def run_show_cases(  # pylint: disable=too-many-arguments,too-many-positional-arguments

--- a/benchmarks/tests/show_cases_test.py
+++ b/benchmarks/tests/show_cases_test.py
@@ -115,6 +115,10 @@ def _make_export_case_call(
         (run_a / "predictions" / "biorxiv" / "doc1.tei.xml").write_bytes(b"<tei-a/>")
         (run_b / "predictions" / "biorxiv").mkdir(parents=True, exist_ok=True)
         (run_b / "predictions" / "biorxiv" / "doc1.tei.xml").write_bytes(b"<tei-b/>")
+        (run_a / "scores" / "biorxiv").mkdir(parents=True, exist_ok=True)
+        (run_a / "scores" / "biorxiv" / "doc1.json").write_bytes(b'{"run":"a"}')
+        (run_b / "scores" / "biorxiv").mkdir(parents=True, exist_ok=True)
+        (run_b / "scores" / "biorxiv" / "doc1.json").write_bytes(b'{"run":"b"}')
     _export_case(
         out_dir, "doc1", "biorxiv", "title",
         gold_text, text_a, text_b,
@@ -162,6 +166,8 @@ class TestExportCase:
         assert (out_dir / "doc1.jats.xml").read_bytes() == b"<jats/>"
         assert (out_dir / "doc1.run-a.tei.xml").read_bytes() == b"<tei-a/>"
         assert (out_dir / "doc1.run-b.tei.xml").read_bytes() == b"<tei-b/>"
+        assert (out_dir / "doc1.run-a.scores.json").read_bytes() == b'{"run":"a"}'
+        assert (out_dir / "doc1.run-b.scores.json").read_bytes() == b'{"run":"b"}'
 
     def test_skips_missing_source_files(self, tmp_path: Path):
         out_dir = tmp_path / "examples"
@@ -170,6 +176,8 @@ class TestExportCase:
         assert not (out_dir / "doc1.jats.xml").exists()
         assert not (out_dir / "doc1.run-a.tei.xml").exists()
         assert not (out_dir / "doc1.run-b.tei.xml").exists()
+        assert not (out_dir / "doc1.run-a.scores.json").exists()
+        assert not (out_dir / "doc1.run-b.scores.json").exists()
 
 
 class TestFindCases:


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/89

Copies run-a and run-b score files from runs/scores/{corpus}/ into the examples directory as {record_id}.run-a.scores.json / run-b.scores.json, making it easier to inspect the full scoring breakdown for each regression or improvement case without navigating the runs directory manually.