### PR TITLE
Add on-demand pdfalto XML export to dev-show-regressions/improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ SHOW_CORPUS ?= biorxiv
 SHOW_LIMIT ?= 10
 SHOW_RUN_A ?= $(BENCHMARK_RUN)
 SHOW_RUN_B ?= $(shell python3 -c "import yaml; b=yaml.safe_load(open('benchmarks/eval.yml')).get('baselines',[]); print('benchmarks/runs/baselines/'+b[0]['tool']+'/'+b[0]['version']+'/$(BENCHMARK_SPLIT)') if b else print('')" 2>/dev/null)
+SHOW_PARSER_URL ?=
 
 COMPARE_MODEL ?= segmentation
 COMPARE_DOC_ID ?= $(basename $(notdir $(COMPARE_PDF)))
@@ -212,7 +213,8 @@ dev-show-regressions: .require-SHOW_FIELD
 		--mode regression \
 		--data benchmarks/data \
 		--split $(BENCHMARK_SPLIT) \
-		--limit $(SHOW_LIMIT)
+		--limit $(SHOW_LIMIT) \
+		$(if $(SHOW_PARSER_URL),--parser-url $(SHOW_PARSER_URL),)
 
 
 dev-show-improvements: .require-SHOW_FIELD
@@ -225,7 +227,8 @@ dev-show-improvements: .require-SHOW_FIELD
 		--mode improvement \
 		--data benchmarks/data \
 		--split $(BENCHMARK_SPLIT) \
-		--limit $(SHOW_LIMIT)
+		--limit $(SHOW_LIMIT) \
+		$(if $(SHOW_PARSER_URL),--parser-url $(SHOW_PARSER_URL),)
 
 
 dev-benchmark-with-baselines:

--- a/benchmarks/show_cases.py
+++ b/benchmarks/show_cases.py
@@ -9,6 +9,9 @@ from io import BytesIO
 from pathlib import Path
 from typing import List, Optional, Tuple
 
+import httpx
+from lxml import etree as lxml_etree
+
 from sciencebeam_judge.parsing.xml import parse_xml, parse_xml_mapping
 from sciencebeam_judge.parsing.xpath.xpath_functions import register_functions
 from sciencebeam_judge.resources import DEFAULT_XML_MAPPING_PATH
@@ -180,6 +183,33 @@ def _print_case(  # pylint: disable=too-many-arguments,too-many-positional-argum
     print()
 
 
+_PDFALTO_ENDPOINT = "/api/pdfalto"
+
+
+def _pretty_print_xml(content: bytes) -> bytes:
+    try:
+        root = lxml_etree.fromstring(content)
+        return lxml_etree.tostring(root, pretty_print=True, xml_declaration=True, encoding="UTF-8")
+    except lxml_etree.XMLSyntaxError:
+        return content
+
+
+def _fetch_pdfalto_xml(parser_url: str, pdf_path: Path) -> Optional[bytes]:
+    """POST a PDF to the pdfalto endpoint and return the ALTO XML bytes, or None on failure."""
+    try:
+        with httpx.Client() as client:
+            response = client.post(
+                f"{parser_url}{_PDFALTO_ENDPOINT}",
+                files={"input": (pdf_path.name, pdf_path.read_bytes(), "application/pdf")},
+                timeout=60,
+            )
+            response.raise_for_status()
+            return response.content
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        LOGGER.warning("Failed to fetch pdfalto XML for %s: %s", pdf_path.name, exc)
+        return None
+
+
 def _copy_if_exists(src: Path, dst: Path) -> None:
     if src.exists():
         shutil.copy(src, dst)
@@ -197,6 +227,7 @@ def _export_case(
     run_b: Path,
     data_dir: Path,
     split: str,
+    alto_xml: Optional[bytes] = None,
 ) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     for suffix, text in [
@@ -228,6 +259,8 @@ def _export_case(
         run_b / "scores" / corpus / f"{record_id}.json",
         out_dir / f"{record_id}.run-b.scores.json",
     )
+    if alto_xml is not None:
+        (out_dir / f"{record_id}.alto.xml").write_bytes(_pretty_print_xml(alto_xml))
 
 
 def run_show_cases(  # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -241,6 +274,7 @@ def run_show_cases(  # pylint: disable=too-many-arguments,too-many-positional-ar
     data_dir: Path,
     split: str,
     limit: Optional[int],
+    parser_url: Optional[str] = None,
 ) -> None:
     register_functions()
     xml_mapping = parse_xml_mapping(DEFAULT_XML_MAPPING_PATH)
@@ -262,6 +296,11 @@ def run_show_cases(  # pylint: disable=too-many-arguments,too-many-positional-ar
         gold_text, text_a, text_b = _extract_texts(
             corp, record_id, run_a, run_b, data_dir, split, field, xml_mapping,
         )
+        alto_xml = None
+        if parser_url:
+            pdf_path = data_dir / split / corp / f"{record_id}.pdf"
+            if pdf_path.exists():
+                alto_xml = _fetch_pdfalto_xml(parser_url, pdf_path)
         _print_case(
             delta, corp, record_id, score_a, score_b,
             label_a, label_b, gold_text, text_a, text_b,
@@ -270,6 +309,7 @@ def run_show_cases(  # pylint: disable=too-many-arguments,too-many-positional-ar
             examples_base / corp, record_id, corp, field,
             gold_text, text_a, text_b,
             run_a, run_b, data_dir, split,
+            alto_xml=alto_xml,
         )
 
     if to_show:
@@ -291,6 +331,10 @@ def main(argv=None) -> None:
     parser.add_argument("--data", default="benchmarks/data", type=Path)
     parser.add_argument("--split", default="train")
     parser.add_argument("--limit", type=int, default=10)
+    parser.add_argument(
+        "--parser-url", default=None,
+        help="Parser URL for on-demand pdfalto XML export (e.g. http://localhost:8080)"
+    )
     args = parser.parse_args(argv)
 
     logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(message)s")
@@ -305,6 +349,7 @@ def main(argv=None) -> None:
         data_dir=args.data,
         split=args.split,
         limit=args.limit,
+        parser_url=args.parser_url,
     )
 
 

--- a/benchmarks/tests/show_cases_test.py
+++ b/benchmarks/tests/show_cases_test.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Optional
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -9,6 +11,7 @@ from benchmarks.show_cases import (
     _comparison_label,
     _copy_if_exists,
     _export_case,
+    _fetch_pdfalto_xml,
     _get_doc_score,
     _run_label,
     find_cases,
@@ -103,6 +106,7 @@ def _make_export_case_call(
     out_dir: Path, tmp_path: Path,
     gold_text=None, text_a=None, text_b=None,
     with_source_files=False,
+    alto_xml: Optional[bytes] = None,
 ):
     run_a = tmp_path / "run_a"
     run_b = tmp_path / "run_b"
@@ -123,7 +127,36 @@ def _make_export_case_call(
         out_dir, "doc1", "biorxiv", "title",
         gold_text, text_a, text_b,
         run_a, run_b, data_dir, "train",
+        alto_xml=alto_xml,
     )
+
+
+class TestFetchPdfaltoXml:
+    def _mock_client(self, content: bytes):
+        mock_response = MagicMock()
+        mock_response.content = content
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_response
+        return mock_client
+
+    def test_returns_content_on_success(self, tmp_path: Path):
+        pdf = tmp_path / "doc.pdf"
+        pdf.write_bytes(b"pdf")
+        with patch(
+            "benchmarks.show_cases.httpx.Client", return_value=self._mock_client(b"<alto/>")
+        ):
+            result = _fetch_pdfalto_xml("http://localhost:8080", pdf)
+        assert result == b"<alto/>"
+
+    def test_returns_none_on_error(self, tmp_path: Path):
+        pdf = tmp_path / "doc.pdf"
+        pdf.write_bytes(b"pdf")
+        with patch("benchmarks.show_cases.httpx.Client") as mock_cls:
+            mock_cls.return_value.__enter__.return_value.post.side_effect = Exception("conn error")
+            result = _fetch_pdfalto_xml("http://localhost:8080", pdf)
+        assert result is None
 
 
 class TestCopyIfExists:
@@ -178,6 +211,19 @@ class TestExportCase:
         assert not (out_dir / "doc1.run-b.tei.xml").exists()
         assert not (out_dir / "doc1.run-a.scores.json").exists()
         assert not (out_dir / "doc1.run-b.scores.json").exists()
+
+    def test_writes_alto_xml_when_provided(self, tmp_path: Path):
+        out_dir = tmp_path / "examples"
+        _make_export_case_call(out_dir, tmp_path, alto_xml=b"<alto><Page/></alto>")
+        content = (out_dir / "doc1.alto.xml").read_bytes()
+        assert b"<alto>" in content
+        assert b"<Page/>" in content
+        assert b"\n" in content  # formatted
+
+    def test_skips_alto_xml_when_none(self, tmp_path: Path):
+        out_dir = tmp_path / "examples"
+        _make_export_case_call(out_dir, tmp_path, alto_xml=None)
+        assert not (out_dir / "doc1.alto.xml").exists()
 
 
 class TestFindCases:


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/90

When SHOW_PARSER_URL is set, show_cases.py fetches the ALTO XML for each exported case from the running parser and saves it as {record_id}.alto.xml, pretty-printed via lxml for readability. Failures are logged as warnings and skipped so the export continues offline when the URL is absent.