### PR TITLE
Fix get_text_pattern and preserve_first_page_head defaults to match GROBID

### DIFF
--- a/sciencebeam_parser/document/layout_noise_filter.py
+++ b/sciencebeam_parser/document/layout_noise_filter.py
@@ -31,8 +31,11 @@ class LayoutNoiseFilterConfig:
     # Occurrences whose height exceeds this multiple of the group median are not filtered
     # (catches e.g. a large title on page 1 that also repeats as a small footer)
     max_height_ratio: float = 2.0
-    # Never filter running-head blocks on page 1 (the paper title lives there)
-    preserve_first_page_head: bool = True
+    # Never filter running-head blocks on page 1.
+    # Only needed when the page-1 title has the same height as the running head
+    # (otherwise the height check already preserves it). Defaults to False because
+    # setting True will also preserve genuine running-head blocks on page 1.
+    preserve_first_page_head: bool = False
     # Never filter running-foot blocks on page 1 (footers have no special status on page 1)
     preserve_first_page_foot: bool = False
 

--- a/sciencebeam_parser/models/segmentation/data.py
+++ b/sciencebeam_parser/models/segmentation/data.py
@@ -136,8 +136,8 @@ def calculate_page_main_areas(  # pylint: disable=too-many-locals,too-many-branc
 # based on:
 # https://github.com/kermitt2/grobid/blob/0.6.2/grobid-core/src/main/java/org/grobid/core/features/FeatureFactory.java#L359-L367
 def get_text_pattern(text: str) -> str:
-    # Note: original code is meant to shadow numbers but are actually removed
-    return re.sub(r'[^a-zA-Z ]', '', text).lower()
+    # Matches GROBID's FeatureFactory.getPattern: remove everything except letters, then lowercase
+    return re.sub(r'[^a-zA-Z]', '', text).lower()
 
 
 def count_block_tokens_like_grobid(block_lines: List[LayoutLine]) -> int:
@@ -280,7 +280,7 @@ class SegmentationLineFeaturesProvider:
         pattern_by_line_id = {
             key: value
             for key, value in all_pattern_by_line_id.items()
-            if len(value) >= 8  # Java GROBID sometimes counts an additional trailing space
+            if len(value) > 8  # matches GROBID: pattern.length() > 8
         }
         pattern_counter = Counter(pattern_by_line_id.values())
         LOGGER.debug('pattern_counter: %s', pattern_counter)

--- a/sciencebeam_parser/processors/fulltext/config.py
+++ b/sciencebeam_parser/processors/fulltext/config.py
@@ -50,7 +50,7 @@ class FullTextProcessorConfig(NamedTuple):
     max_graphic_distance: float = DEFAULT_MAX_GRAPHIC_DISTANCE
     noise_filter_enabled: bool = False
     noise_filter_repetition_fraction: float = 0.5
-    noise_filter_preserve_first_page_head: bool = True
+    noise_filter_preserve_first_page_head: bool = False
     noise_filter_preserve_first_page_foot: bool = False
 
     @staticmethod

--- a/sciencebeam_parser/resources/default_config/config.yml
+++ b/sciencebeam_parser/resources/default_config/config.yml
@@ -74,7 +74,7 @@ lookup:
       - https://raw.githubusercontent.com/kermitt2/grobid/0.6.2/grobid-home/lexicon/names/names.family
 processors:
   fulltext:
-    noise_filter_enabled: false
+    noise_filter_enabled: true
     noise_filter_repetition_fraction: 0.5
     noise_filter_preserve_first_page_head: false
     noise_filter_preserve_first_page_foot: false

--- a/sciencebeam_parser/resources/default_config/config.yml
+++ b/sciencebeam_parser/resources/default_config/config.yml
@@ -74,9 +74,9 @@ lookup:
       - https://raw.githubusercontent.com/kermitt2/grobid/0.6.2/grobid-home/lexicon/names/names.family
 processors:
   fulltext:
-    noise_filter_enabled: true
+    noise_filter_enabled: false
     noise_filter_repetition_fraction: 0.5
-    noise_filter_preserve_first_page_head: true
+    noise_filter_preserve_first_page_head: false
     noise_filter_preserve_first_page_foot: false
     merge_raw_authors: false
     use_cv_model: false

--- a/tests/document/layout_noise_filter_test.py
+++ b/tests/document/layout_noise_filter_test.py
@@ -87,7 +87,7 @@ class TestGetNoiseBlocks:
         )
         result = get_noise_blocks(doc, ENABLED_CONFIG)
         assert {nb.note_type for nb in result} == {'running-head'}
-        assert len(result) == 2  # page 1 preserved by default
+        assert len(result) == 3
 
     def test_detects_running_foot_at_bottom(self):
         # y=950 → y_rel=0.95, well above q3 of each page
@@ -149,7 +149,7 @@ class TestGetNoiseBlocks:
             _page_with_body([_block_at_y('journal name', y=10)], page_number=2),
         )
         result = get_noise_blocks(doc, ENABLED_CONFIG)
-        assert len(result) == 1  # page 1 preserved by default
+        assert len(result) == 2
 
     def test_large_title_on_first_page_not_filtered_when_repeated_as_small_footer(self):
         # Regression (scielo_br): a paper title appears large (height=60) near the

--- a/tests/models/segmentation/data_test.py
+++ b/tests/models/segmentation/data_test.py
@@ -44,8 +44,8 @@ class TestGetTextPattern:
     def test_should_keep_uppercase_characters_and_convert_to_lowercase(self):
         assert get_text_pattern('ABC') == 'abc'
 
-    def test_should_keep_spaces(self):
-        assert get_text_pattern('abc abc') == 'abc abc'
+    def test_should_remove_spaces(self):
+        assert get_text_pattern('abc abc') == 'abcabc'
 
     def test_should_remove_punctuation(self):
         assert get_text_pattern('abc.,:;') == 'abc'


### PR DESCRIPTION
related to https://github.com/eLifePathways/ScienceBeam2.0/issues/88

Align get_text_pattern with GROBID's FeatureFactory.getPattern:
- Remove spaces from pattern (was: kept spaces), matching [^a-zA-Z]
- Restore threshold to > 8 (was: >= 8 as a workaround for the space bug)

The >= 8 threshold was introduced in e66fe3e to compensate for the trailing space that the incorrect regex preserved; with spaces now removed the original > 8 is correct.

Change preserve_first_page_head default to false: a page-1 running head that is the same size as its recurrences on later pages is genuine noise and should be filtered. The height check (max_height_ratio) already handles the legitimate case where the page-1 title is larger than the running head copies.