### PR TITLE
Disable noise filter for grobid_crf profile

### DIFF
--- a/sciencebeam_parser/resources/default_config/config.yml
+++ b/sciencebeam_parser/resources/default_config/config.yml
@@ -176,6 +176,9 @@ profiles:
     sequence_models: biorxiv_elife
   grobid_crf_0_9_0:
     sequence_models: grobid_crf_0_9_0
+    processors:
+      fulltext:
+        noise_filter_enabled: false
 
 profile_aliases:
   grobid_crf: grobid_crf_0_9_0


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/88

The noise filter harms prediction quality when using GROBID CRF/wapiti models. Override processors.fulltext.noise_filter_enabled to false in the grobid_crf_0_9_0 profile; biorxiv_elife continues to use the base default (enabled).