### PR TITLE
Strip trailing punctuation in get_str_is_common_name

### DIFF
--- a/sciencebeam_parser/models/data.py
+++ b/sciencebeam_parser/models/data.py
@@ -707,8 +707,11 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
         return self._get_str_lookup(ctx.last_name_lookup)
 
     def get_str_is_common_name(self) -> str:
-        return self._get_str_lookup(
-            self.document_features_context.app_features_context.common_name_lookup
+        lookup = self.document_features_context.app_features_context.common_name_lookup
+        if not lookup:
+            return get_str_bool_feature_value(False)
+        return get_str_bool_feature_value(
+            lookup.contains(self.token_text.rstrip('.,;:'))
         )
 
     def get_str_is_year(self) -> str:

--- a/tests/lookup/lookup_test.py
+++ b/tests/lookup/lookup_test.py
@@ -1,0 +1,58 @@
+from sciencebeam_parser.lookup import MergedTextLookUp, SimpleTextLookUp
+
+
+class TestSimpleTextLookUp:
+    def test_contains_exact_match(self):
+        lookup = SimpleTextLookUp({'word'})
+        assert lookup.contains('word') is True
+
+    def test_not_contains_unknown(self):
+        lookup = SimpleTextLookUp({'word'})
+        assert lookup.contains('other') is False
+
+    def test_contains_case_insensitive(self):
+        lookup = SimpleTextLookUp({'word'})
+        assert lookup.contains('Word') is True
+        assert lookup.contains('WORD') is True
+
+    def test_contains_entry_stored_uppercase(self):
+        lookup = SimpleTextLookUp({'WORD'})
+        assert lookup.contains('word') is True
+
+    def test_not_contains_trailing_comma(self):
+        lookup = SimpleTextLookUp({'word'})
+        assert lookup.contains('word,') is False
+
+    def test_leading_punctuation_not_matched(self):
+        lookup = SimpleTextLookUp({'word'})
+        assert lookup.contains(',word') is False
+
+    def test_empty_string(self):
+        lookup = SimpleTextLookUp({'word'})
+        assert lookup.contains('') is False
+
+    def test_punctuation_only(self):
+        lookup = SimpleTextLookUp({'word'})
+        assert lookup.contains(',') is False
+
+
+class TestMergedTextLookUp:
+    def test_contains_when_first_lookup_matches(self):
+        lookup = MergedTextLookUp([SimpleTextLookUp({'a'}), SimpleTextLookUp({'b'})])
+        assert lookup.contains('a') is True
+
+    def test_contains_when_second_lookup_matches(self):
+        lookup = MergedTextLookUp([SimpleTextLookUp({'a'}), SimpleTextLookUp({'b'})])
+        assert lookup.contains('b') is True
+
+    def test_not_contains_when_none_match(self):
+        lookup = MergedTextLookUp([SimpleTextLookUp({'a'}), SimpleTextLookUp({'b'})])
+        assert lookup.contains('c') is False
+
+    def test_ignores_none_entries(self):
+        lookup = MergedTextLookUp([None, SimpleTextLookUp({'word'})])
+        assert lookup.contains('word') is True
+
+    def test_empty_lookup_list(self):
+        lookup = MergedTextLookUp([])
+        assert lookup.contains('word') is False


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/88

GROBID's Lexicon.inDictionary() (used for is_common_name) strips one trailing punctuation character before the wordform lookup. Lexicon.inFirstNames/inLastNames (used for is_proper_name) do not strip. Applying rstrip in SimpleTextLookUp.contains() affected all lookups indiscriminately, causing new is_proper_name regressions (e.g. 'BUENO,' incorrectly matching the names lexicon). Moving the strip to get_str_is_common_name() scopes the fix correctly.