### PR TITLE
Truncate font size to int before comparison, matching GROBID behaviour

### DIFF
--- a/sciencebeam_parser/models/data.py
+++ b/sciencebeam_parser/models/data.py
@@ -170,9 +170,13 @@ def get_token_font_size_feature(
     current_font_size = current_token.font.font_size
     if not previous_font_size or not current_font_size:
         return 'HIGHERFONT'
-    if previous_font_size < current_font_size:
+    # GROBID truncates font sizes to int before comparison ((int) token.getFontSize()),
+    # absorbing sub-point float noise from pdfalto.
+    prev_int = int(previous_font_size)
+    curr_int = int(current_font_size)
+    if prev_int < curr_int:
         return 'HIGHERFONT'
-    if previous_font_size > current_font_size:
+    if prev_int > curr_int:
         return 'LOWERFONT'
     return 'SAMEFONTSIZE'
 

--- a/tests/models/data_test.py
+++ b/tests/models/data_test.py
@@ -258,6 +258,38 @@ class TestGetTokenFontSizeFeature:
             ))
         ) == 'HIGHERFONT'
 
+    def test_should_return_samefontsize_for_sub_integer_float_decrease(self):
+        # GROBID uses (int) cast; 9.96 and 9.5 both truncate to 9 → SAMEFONTSIZE
+        assert get_token_font_size_feature(
+            previous_token=LayoutToken('', font=LayoutFont(
+                font_id='dummy', font_size=9.96
+            )),
+            current_token=LayoutToken('', font=LayoutFont(
+                font_id='dummy', font_size=9.5
+            ))
+        ) == 'SAMEFONTSIZE'
+
+    def test_should_return_samefontsize_for_sub_integer_float_increase(self):
+        assert get_token_font_size_feature(
+            previous_token=LayoutToken('', font=LayoutFont(
+                font_id='dummy', font_size=9.5
+            )),
+            current_token=LayoutToken('', font=LayoutFont(
+                font_id='dummy', font_size=9.96
+            ))
+        ) == 'SAMEFONTSIZE'
+
+    def test_should_return_lowerfont_for_cross_integer_decrease(self):
+        # 9.96 → int 9, 10.5 → int 10: different integers → LOWERFONT
+        assert get_token_font_size_feature(
+            previous_token=LayoutToken('', font=LayoutFont(
+                font_id='dummy', font_size=10.5
+            )),
+            current_token=LayoutToken('', font=LayoutFont(
+                font_id='dummy', font_size=9.96
+            ))
+        ) == 'LOWERFONT'
+
 
 class TestGetDigitFeature:
     def test_should_return_nodigit(self):


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/88

GROBID's Segmentation.java uses `(int) token.getFontSize()` when computing the token_font_size feature (SAMEFONTSIZE / LOWERFONT / HIGHERFONT). sbeam was comparing raw floats, so sub-point pdfalto noise (e.g. 9.5 vs 9.96) produced spurious LOWERFONT/HIGHERFONT values where both sides logically have the same font size.

This eliminates 15 token_font_size differences on the investigated document (S1413-24782006000300002), which in turn resolves the second title block misclassification (tokens 49–53) and three footnote cluster misses driven by the global Viterbi path effect.