### PR TITLE
Fix crash when processing PDFs with invalid pdfalto bounding box coordinates

### DIFF
--- a/sciencebeam_parser/external/pdfalto/parser.py
+++ b/sciencebeam_parser/external/pdfalto/parser.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Dict, List
 
 from lxml import etree
@@ -16,6 +17,8 @@ from sciencebeam_parser.document.layout_document import (
     EMPTY_FONT
 )
 
+
+LOGGER = logging.getLogger(__name__)
 
 ALTO_NS = 'http://www.loc.gov/standards/alto/ns-v3#'
 ALTO_NS_MAP = {
@@ -36,11 +39,20 @@ class AltoParser:
         node: etree.ElementBase,
         page_number: int
     ) -> LayoutPageCoordinates:
+        width = float(node.attrib.get('WIDTH', 0))
+        height = float(node.attrib.get('HEIGHT', 0))
+        if width < 0 or height < 0:
+            LOGGER.warning(
+                'Clamping negative dimensions to zero: width=%r, height=%r, attrib=%r',
+                width, height, dict(node.attrib)
+            )
+            width = max(0.0, width)
+            height = max(0.0, height)
         return LayoutPageCoordinates(
             x=float(node.attrib.get('HPOS', 0)),
             y=float(node.attrib.get('VPOS', 0)),
-            width=float(node.attrib.get('WIDTH', 0)),
-            height=float(node.attrib.get('HEIGHT', 0)),
+            width=width,
+            height=height,
             page_number=page_number
         )
 

--- a/tests/external/pdfalto/parser_test.py
+++ b/tests/external/pdfalto/parser_test.py
@@ -138,6 +138,33 @@ class TestAltoParser:
         )
         assert page.meta.page_number == 11
 
+    def test_should_clamp_negative_token_dimensions_to_zero(self):
+        page = AltoParser().parse_page(
+            ALTO_E.Page(
+                ALTO_E.PrintSpace(
+                    ALTO_E.TextBlock(
+                        ALTO_E.TextLine(
+                            ALTO_E.String(
+                                CONTENT=TOKEN_1,
+                                STYLEREFS=FONT_ID_1,
+                                HPOS='253.44',
+                                VPOS='-94923152',
+                                WIDTH='61.65',
+                                HEIGHT='-48132729'
+                            )
+                        )
+                    )
+                )
+            ),
+            page_index=0
+        )
+        tokens = page.blocks[0].lines[0].tokens
+        assert len(tokens) == 1
+        coords = tokens[0].coordinates
+        assert coords is not None
+        assert coords.width == 61.65
+        assert coords.height == 0.0
+
 
 class TestParseAltoRoot:
     def test_should_parse_simple_document(self):


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/93

pdfalto v0.6.0 emits negative HEIGHT/VPOS values for certain tokens in some PDFs (e.g. 10.1101/2024.05.20.594973), which caused a ValueError in BoundingRange.validate() during segmentation feature extraction. parse_page_coordinates now clamps negative WIDTH/HEIGHT to 0 and logs a warning, making affected tokens produce empty bounding boxes that the intersection logic already handles gracefully.