### PR TITLE
Fix TEI pretty-printing corrupting inline element text content

### DIFF
--- a/sciencebeam_parser/app/parser.py
+++ b/sciencebeam_parser/app/parser.py
@@ -139,13 +139,52 @@ def get_xml_tree(xml_root: etree.ElementBase) -> etree._ElementTree:
     return etree.ElementTree(xml_root)
 
 
+_TEI_BLOCK_ELEMENT_NAMES = frozenset({
+    'TEI', 'teiHeader', 'fileDesc', 'titleStmt', 'publicationStmt',
+    'profileDesc', 'sourceDesc', 'abstract',
+    'text', 'body', 'back', 'front',
+    'div', 'listBibl', 'biblStruct', 'analytic', 'monogr',
+    'figure', 'table', 'row',
+})
+
+
+def _indent_tei_element(
+    element: etree.ElementBase,
+    space: str,
+    level: int
+) -> None:
+    # Only add indentation inside known structural/block TEI elements.
+    # Content elements (title, p, hi, ref, …) are left completely untouched
+    # so their text content can never be corrupted by inserted whitespace.
+    # The tail of a content element is still set by its parent block element,
+    # so it still appears on its own indented line.
+    local_name = etree.QName(element).localname
+    if local_name not in _TEI_BLOCK_ELEMENT_NAMES:
+        return
+    children = list(element)
+    if not children:
+        return
+    indent = '\n' + level * space
+    child_indent = indent + space
+    if not (element.text and element.text.strip()):
+        element.text = child_indent
+    for i, child in enumerate(children):
+        _indent_tei_element(child, space, level + 1)
+        if not (child.tail and child.tail.strip()):
+            child.tail = child_indent if i < len(children) - 1 else indent
+
+
+def _indent_tei(root: etree.ElementBase, space: str = '  ') -> None:
+    _indent_tei_element(root, space=space, level=0)
+
+
 def serialize_xml_to_file(
     xml_root: etree.ElementBase,
     filename: str,
     pretty_print: bool = False
 ):
     if pretty_print:
-        etree.indent(xml_root, space='  ')
+        _indent_tei(xml_root)
     get_xml_tree(xml_root).write(
         filename,
         encoding='utf-8',

--- a/sciencebeam_parser/app/parser.py
+++ b/sciencebeam_parser/app/parser.py
@@ -183,7 +183,11 @@ def serialize_xml_to_file(
     filename: str,
     pretty_print: bool = False
 ):
-    if pretty_print:
+    # _XSLTResultTree (JATS) is an _ElementTree subclass; skip for those
+    is_element_tree = isinstance(
+        xml_root, etree._ElementTree  # pylint: disable=protected-access
+    )
+    if pretty_print and not is_element_tree:
         _indent_tei(xml_root)
     get_xml_tree(xml_root).write(
         filename,

--- a/tests/app/parser_test.py
+++ b/tests/app/parser_test.py
@@ -161,6 +161,7 @@ class TestSerializeXmlToFile:
     def test_should_preserve_mixed_content_text_when_pretty_print(
         self, tmp_path: Path
     ):
+        # p.text and ref.tail are non-empty, so etree guards protect them
         root = etree.fromstring(
             b'<TEI><p>some text <ref>1</ref> more text</p></TEI>'
         )
@@ -169,6 +170,23 @@ class TestSerializeXmlToFile:
         content = Path(filename).read_text(encoding='utf-8')
         assert 'some text ' in content
         assert ' more text' in content
+
+    def test_should_not_insert_whitespace_between_inline_sibling_elements(
+        self, tmp_path: Path
+    ):
+        # title has no direct text; all content is in <hi> children whose
+        # tails are None. Naively indenting would insert newlines between
+        # the <hi> siblings, corrupting the concatenated title text.
+        root = etree.fromstring(
+            b'<TEI><teiHeader><titleStmt>'
+            b'<title><hi>Part 1</hi><hi>Part 2</hi></title>'
+            b'</titleStmt></teiHeader></TEI>'
+        )
+        filename = str(tmp_path / 'output.xml')
+        serialize_xml_to_file(root, filename, pretty_print=True)
+        content = Path(filename).read_text(encoding='utf-8')
+        assert '\n' in content  # structural indentation is still present
+        assert '<hi>Part 1</hi><hi>Part 2</hi>' in content  # siblings stay adjacent
 
     def test_should_not_indent_when_pretty_print_disabled(
         self, tmp_path: Path

--- a/tests/app/parser_test.py
+++ b/tests/app/parser_test.py
@@ -188,6 +188,16 @@ class TestSerializeXmlToFile:
         assert '\n' in content  # structural indentation is still present
         assert '<hi>Part 1</hi><hi>Part 2</hi>' in content  # siblings stay adjacent
 
+    def test_should_not_crash_when_xml_root_is_element_tree(
+        self, tmp_path: Path
+    ):
+        # _XSLTResultTree (used for JATS output) is an _ElementTree subclass,
+        # not a plain element. Indentation must be skipped rather than crashing.
+        tree = etree.ElementTree(etree.fromstring(b'<article>1</article>'))
+        filename = str(tmp_path / 'output.xml')
+        serialize_xml_to_file(tree, filename, pretty_print=True)
+        assert Path(filename).read_bytes() == b'<article>1</article>'
+
     def test_should_not_indent_when_pretty_print_disabled(
         self, tmp_path: Path
     ):


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/94

Replace bare etree.indent() with a structural-whitelist approach: only known block-level TEI elements (teiHeader, div, biblStruct, etc.) receive internal indentation. Content elements (title, p, hi, ref, …) are never touched internally, so inline siblings with None tails cannot have whitespace inserted between them.

Adds a regression test for the title-with-bold case where multiple <hi> siblings would otherwise be separated by newlines.