### PR TITLE
Fix benchmark sampling so smaller modes are always subsets of larger ones

### DIFF
--- a/benchmarks/fetch.py
+++ b/benchmarks/fetch.py
@@ -12,6 +12,18 @@ from huggingface_hub import hf_hub_download
 LOGGER = logging.getLogger(__name__)
 
 
+def _sample_indices(n_total: int, n: int, seed: int) -> set:
+    """Return a deterministic set of n indices from [0, n_total).
+
+    Smaller n always produces a subset of larger n with the same seed,
+    so smoke ⊂ small ⊂ medium ⊂ large ⊂ full for each corpus.
+    """
+    rng = np.random.default_rng(seed)
+    all_indices = np.arange(n_total)
+    rng.shuffle(all_indices)
+    return set(int(i) for i in all_indices[:n])
+
+
 def _get_corpus_filename_and_id_column(entry: Any) -> Tuple[str, str]:
     if isinstance(entry, dict):
         return entry["file"], entry.get("id_column", "id")
@@ -65,8 +77,7 @@ def fetch_data(  # pylint: disable=too-many-locals
         pf = pq.ParquetFile(parquet_path)
         all_ids = pf.read(columns=[id_column]).column(id_column).to_pylist()
         n = min(sample_sizes[corpus], len(all_ids))
-        rng = np.random.default_rng(seed)
-        picked = set(int(i) for i in rng.choice(len(all_ids), size=n, replace=False))
+        picked = _sample_indices(len(all_ids), n, seed)
 
         corpus_dir = data_dir / split / corpus
         corpus_dir.mkdir(parents=True, exist_ok=True)

--- a/benchmarks/tests/fetch_test.py
+++ b/benchmarks/tests/fetch_test.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from benchmarks.fetch import _sample_indices
+
+
+class TestSampleIndices:
+    def test_returns_correct_size(self):
+        assert len(_sample_indices(100, 10, seed=42)) == 10
+
+    def test_is_deterministic(self):
+        assert _sample_indices(100, 10, seed=42) == _sample_indices(100, 10, seed=42)
+
+    def test_different_seeds_give_different_results(self):
+        assert _sample_indices(100, 10, seed=42) != _sample_indices(100, 10, seed=99)
+
+    def test_smaller_is_subset_of_larger(self):
+        s10 = _sample_indices(158, 10, seed=42)
+        s25 = _sample_indices(158, 25, seed=42)
+        s50 = _sample_indices(158, 50, seed=42)
+        assert s10 <= s25
+        assert s25 <= s50
+        assert s10 <= s50
+
+    def test_caps_at_n_total(self):
+        assert len(_sample_indices(30, 100, seed=42)) == 30
+
+    def test_indices_within_range(self):
+        n_total = 50
+        assert _sample_indices(n_total, 20, seed=42) <= set(range(n_total))


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/95

Replaces random.choice with shuffle-then-slice so smoke ⊂ small ⊂ medium ⊂ large ⊂ full for every corpus. Previously, a PR benchmarked on smoke would be scored against different documents than the medium-mode baselines, causing the comparison report to show mismatched doc counts (e.g. 43 vs 60). Now all three columns in the report are scored on the same document set.