### PR TITLE
Fixed CI arm build test that was failing to install poppler

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -121,7 +121,7 @@ jobs:
               --ignore=tests/cv_models
               tests/
           - runs-on: ubuntu-24.04-arm
-            install-poppler: sudo apt-get install -y poppler-utils
+            install-poppler: sudo apt-get update && sudo apt-get install -y poppler-utils
             pytest-args: >-
               tests/external/pdfalto/url_test.py
               tests/external/pdfalto/parser_test.py


### PR DESCRIPTION
Error:

> E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/p/poppler/libpoppler134_24.02.0-1ubuntu9.8_arm64.deb  404  Not Found
> E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/p/poppler/poppler-utils_24.02.0-1ubuntu9.8_arm64.deb  404  Not Found
> E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?