### PR TITLE
Parallelise benchmark predictions and add live progress reporting

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -240,6 +240,7 @@ jobs:
             PROFILE_ENV=(-e "SCIENCEBEAM_PARSER__PROFILE=${{ env.BENCHMARK_PROFILE }}")
           fi
           docker run -d --name sciencebeam-parser -p 8080:8070 \
+            -e SCIENCEBEAM_PARSER__PRELOAD_ON_STARTUP=true \
             "${PROFILE_ENV[@]}" ${{ steps.image_tag.outputs.value }}
 
       - name: Wait for parser

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ GROBID_CONTAINER_NAME ?= grobid-compare
 GROBID_WAIT_RETRIES ?= 120
 GROBID_WAIT_INTERVAL ?= 5
 BENCHMARK_PARSER_URL ?= $(SCIENCEBEAM_PARSER_URL)
+BENCHMARK_CONCURRENCY ?= 0
 
 SHOW_FIELD ?=
 SHOW_METHOD ?= edit_sim
@@ -212,6 +213,7 @@ dev-benchmark-predict:
 		--split $(BENCHMARK_SPLIT) \
 		--out $(BENCHMARK_RUN) \
 		--parser-url $(BENCHMARK_PARSER_URL) \
+		--concurrency $(BENCHMARK_CONCURRENCY) \
 		$(ARGS)
 
 

--- a/benchmarks/predict.py
+++ b/benchmarks/predict.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
 import logging
+import os
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import httpx
 import yaml
@@ -15,6 +17,13 @@ from benchmarks.fetch import fetch_data
 LOGGER = logging.getLogger(__name__)
 
 CONVERT_ENDPOINT = "/api/processFulltextDocument"
+DEFAULT_CONCURRENCY = 0  # 0 = auto: max(2, cpu_count)
+
+
+def _resolve_concurrency(concurrency: int) -> int:
+    if concurrency == 0:
+        return max(2, os.cpu_count() or 2)
+    return concurrency
 
 
 def _manifest_path(run_dir: Path) -> Path:
@@ -42,27 +51,129 @@ def _append_manifest(run_dir: Path, entry: Dict[str, Any]) -> None:
         f.write(json.dumps(entry) + "\n")
 
 
-def _predict_one(
-    client: httpx.Client,
+def _format_eta(seconds: float) -> str:
+    if seconds >= 3600:
+        return f"{seconds / 3600:.1f}h"
+    if seconds >= 60:
+        return f"{int(seconds) // 60}m{int(seconds) % 60:02d}s"
+    return f"{seconds:.0f}s"
+
+
+class _Progress:
+    def __init__(self, total: int) -> None:
+        self.total = total
+        self.n_ok = 0
+        self.n_err = 0
+        self._t_start = time.monotonic()
+
+    @property
+    def completed(self) -> int:
+        return self.n_ok + self.n_err
+
+    def record_ok(self, corpus: str, record_id: str, elapsed_ms: int) -> None:
+        self.n_ok += 1
+        self._log(corpus, record_id, "ok", elapsed_ms)
+
+    def record_err(self, corpus: str, record_id: str) -> None:
+        self.n_err += 1
+        self._log(corpus, record_id, "err", 0)
+
+    def _log(
+        self, corpus: str, record_id: str, status: str, elapsed_ms: int
+    ) -> None:
+        elapsed = time.monotonic() - self._t_start
+        done = self.completed
+        rate = done / elapsed if elapsed > 0 else 0.0
+        remaining = self.total - done
+        eta = _format_eta(remaining / rate) if rate > 0 else "?"
+        LOGGER.info(
+            "[%d/%d] %s/%s %s %dms | %.1f doc/s | ~%s left",
+            done, self.total, corpus, record_id, status, elapsed_ms, rate, eta,
+        )
+
+
+async def _run_predict_async(
+    records: List[Dict[str, Any]],
+    done: set,
+    run_dir: Path,
     parser_url: str,
-    pdf_path: Path,
-    out_path: Path,
     timeout: int,
-) -> int:
-    """POST one PDF to the parser, write the JATS XML response. Returns elapsed ms."""
-    t0 = time.monotonic()
-    response = client.post(
-        f"{parser_url}{CONVERT_ENDPOINT}",
-        files={"input": (pdf_path.name, pdf_path.read_bytes(), "application/pdf")},
-        timeout=timeout,
+    concurrency: int,
+) -> Tuple[int, int]:
+    to_process = [
+        r for r in records if (r["corpus"], r["record_id"]) not in done
+    ]
+    skipped = len(records) - len(to_process)
+    if skipped:
+        LOGGER.info("Skipping %d already-cached documents", skipped)
+    LOGGER.info(
+        "Processing %d documents (concurrency=%d)", len(to_process), concurrency
     )
-    response.raise_for_status()
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_bytes(response.content)
-    return round((time.monotonic() - t0) * 1000)
+
+    progress = _Progress(len(to_process))
+    sem = asyncio.Semaphore(concurrency)
+
+    async with httpx.AsyncClient() as client:
+
+        async def _process_one(rec: Dict[str, Any]) -> None:
+            corpus = rec["corpus"]
+            record_id = rec["record_id"]
+            out_path = (
+                run_dir / "predictions" / corpus / f"{record_id}.tei.xml"
+            )
+            async with sem:
+                t0 = time.monotonic()
+                try:
+                    pdf_bytes = Path(rec["pdf_path"]).read_bytes()
+                    response = await client.post(
+                        f"{parser_url}{CONVERT_ENDPOINT}",
+                        files={
+                            "input": (
+                                Path(rec["pdf_path"]).name,
+                                pdf_bytes,
+                                "application/pdf",
+                            )
+                        },
+                        timeout=timeout,
+                    )
+                    response.raise_for_status()
+                    elapsed_ms = round((time.monotonic() - t0) * 1000)
+                    out_path.parent.mkdir(parents=True, exist_ok=True)
+                    out_path.write_bytes(response.content)
+                    _append_manifest(run_dir, {
+                        "corpus": corpus, "record_id": record_id,
+                        "status": "ok", "elapsed_ms": elapsed_ms,
+                    })
+                    progress.record_ok(corpus, record_id, elapsed_ms)
+                except httpx.HTTPStatusError as exc:
+                    msg = str(exc)
+                    body = exc.response.text[:2000] if exc.response.text else ""
+                    if body:
+                        LOGGER.error(
+                            "err %s/%s  %s\n%s", corpus, record_id, msg, body
+                        )
+                    else:
+                        LOGGER.error("err %s/%s  %s", corpus, record_id, msg)
+                    _append_manifest(run_dir, {
+                        "corpus": corpus, "record_id": record_id,
+                        "status": "error", "error": msg, "error_body": body,
+                    })
+                    progress.record_err(corpus, record_id)
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    msg = str(exc)
+                    _append_manifest(run_dir, {
+                        "corpus": corpus, "record_id": record_id,
+                        "status": "error", "error": msg,
+                    })
+                    progress.record_err(corpus, record_id)
+                    LOGGER.error("err %s/%s  %s", corpus, record_id, msg)
+
+        await asyncio.gather(*[_process_one(rec) for rec in to_process])
+
+    return progress.n_ok, progress.n_err
 
 
-def run_predict(  # pylint: disable=too-many-locals
+def run_predict(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     config: dict,
     mode: str,
     split: str,
@@ -71,41 +182,20 @@ def run_predict(  # pylint: disable=too-many-locals
     parser_url: str,
     parser_image: Optional[str],
     profile: Optional[str],
+    concurrency: int = DEFAULT_CONCURRENCY,
 ) -> None:
     records = fetch_data(config, mode, split, data_dir)
     done = _load_done(run_dir)
 
-    n_ok = n_err = 0
     t_start = time.monotonic()
     timeout = config.get("parser", {}).get("timeout_seconds", 60)
 
-    with httpx.Client() as client:
-        for rec in records:
-            corpus, record_id = rec["corpus"], rec["record_id"]
-
-            if (corpus, record_id) in done:
-                LOGGER.info("skip cached  %s/%s", corpus, record_id)
-                continue
-
-            out_path = run_dir / "predictions" / corpus / f"{record_id}.tei.xml"
-            try:
-                elapsed_ms = _predict_one(
-                    client, parser_url, Path(rec["pdf_path"]), out_path, timeout
-                )
-                _append_manifest(run_dir, {
-                    "corpus": corpus, "record_id": record_id,
-                    "status": "ok", "elapsed_ms": elapsed_ms,
-                })
-                n_ok += 1
-                LOGGER.info("ok  %s/%s  %dms", corpus, record_id, elapsed_ms)
-            except Exception as exc:  # pylint: disable=broad-exception-caught
-                msg = str(exc)
-                _append_manifest(run_dir, {
-                    "corpus": corpus, "record_id": record_id,
-                    "status": "error", "error": msg,
-                })
-                n_err += 1
-                LOGGER.error("err %s/%s  %s", corpus, record_id, msg)
+    n_ok, n_err = asyncio.run(
+        _run_predict_async(
+            records, done, run_dir, parser_url, timeout,
+            _resolve_concurrency(concurrency),
+        )
+    )
 
     run_dir.mkdir(parents=True, exist_ok=True)
     (run_dir / "run.json").write_text(json.dumps({
@@ -122,7 +212,10 @@ def run_predict(  # pylint: disable=too-many-locals
         "elapsed_s": round(time.monotonic() - t_start, 1),
     }, indent=2))
 
-    LOGGER.info("done  ok=%d  err=%d  elapsed=%.1fs", n_ok, n_err, time.monotonic() - t_start)
+    LOGGER.info(
+        "done  ok=%d  err=%d  elapsed=%.1fs",
+        n_ok, n_err, time.monotonic() - t_start,
+    )
 
 
 def main(argv: Optional[List[str]] = None) -> None:
@@ -135,14 +228,25 @@ def main(argv: Optional[List[str]] = None) -> None:
         help="Sampling mode defined in eval.yml (e.g. smoke, small, medium, large, full)"
     )
     parser.add_argument(
-        "--split", default="train", help="Dataset split: train (local) or validation (CI)"
+        "--split", default="train",
+        help="Dataset split: train (local) or validation (CI)",
     )
-    parser.add_argument("--data", default="benchmarks/data", help="Data cache directory")
-    parser.add_argument("--out", required=True, help="Run output dir, e.g. benchmarks/runs/local")
+    parser.add_argument(
+        "--data", default="benchmarks/data", help="Data cache directory"
+    )
+    parser.add_argument(
+        "--out", required=True, help="Run output dir, e.g. benchmarks/runs/local"
+    )
     parser.add_argument("--parser-url", default="http://localhost:8080")
-    parser.add_argument("--parser-image", default=None, help="Docker image tag (provenance only)")
+    parser.add_argument(
+        "--parser-image", default=None, help="Docker image tag (provenance only)"
+    )
     parser.add_argument(
         "--profile", default=None, help="Model configuration profile name"
+    )
+    parser.add_argument(
+        "--concurrency", type=int, default=DEFAULT_CONCURRENCY,
+        help="Concurrent requests to the parser (0 = auto: max(2, cpu_count))",
     )
     args = parser.parse_args(argv)
 
@@ -160,6 +264,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         parser_url=args.parser_url,
         parser_image=args.parser_image,
         profile=args.profile,
+        concurrency=args.concurrency,
     )
 
 

--- a/benchmarks/tests/predict_test.py
+++ b/benchmarks/tests/predict_test.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 
+import asyncio
 import json
+import os
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from benchmarks.predict import _append_manifest, _load_done
+import httpx
+
+from benchmarks.predict import (
+    _append_manifest,
+    _format_eta,
+    _load_done,
+    _Progress,
+    _resolve_concurrency,
+    _run_predict_async,
+)
 
 
 class TestLoadDone:
@@ -63,3 +75,173 @@ class TestAppendManifest:
         assert len(lines) == 2
         assert json.loads(lines[0])["record_id"] == "r1"
         assert json.loads(lines[1])["record_id"] == "r2"
+
+
+class TestResolveConcurrency:
+    def test_explicit_value_returned_unchanged(self):
+        assert _resolve_concurrency(4) == 4
+
+    def test_zero_returns_at_least_two(self):
+        assert _resolve_concurrency(0) >= 2
+
+    def test_zero_returns_cpu_count_or_higher(self):
+        expected = max(2, os.cpu_count() or 2)
+        assert _resolve_concurrency(0) == expected
+
+
+class TestFormatEta:
+    def test_seconds(self):
+        assert _format_eta(45.0) == "45s"
+
+    def test_minutes(self):
+        assert _format_eta(90.0) == "1m30s"
+
+    def test_hours(self):
+        assert _format_eta(7200.0) == "2.0h"
+
+    def test_boundary_one_minute(self):
+        assert _format_eta(60.0) == "1m00s"
+
+    def test_boundary_one_hour(self):
+        assert _format_eta(3600.0) == "1.0h"
+
+
+class TestProgress:
+    def test_initial_state(self):
+        p = _Progress(10)
+        assert p.total == 10
+        assert p.n_ok == 0
+        assert p.n_err == 0
+        assert p.completed == 0
+
+    def test_record_ok_increments(self):
+        p = _Progress(10)
+        p.record_ok("biorxiv", "doc1", 1000)
+        assert p.n_ok == 1
+        assert p.n_err == 0
+        assert p.completed == 1
+
+    def test_record_err_increments(self):
+        p = _Progress(10)
+        p.record_err("biorxiv", "doc1")
+        assert p.n_ok == 0
+        assert p.n_err == 1
+        assert p.completed == 1
+
+    def test_completed_sums_ok_and_err(self):
+        p = _Progress(10)
+        p.record_ok("biorxiv", "doc1", 500)
+        p.record_err("biorxiv", "doc2")
+        assert p.completed == 2
+
+
+def _make_record(tmp_path: Path, corpus: str = "biorxiv", record_id: str = "doc1") -> dict:
+    pdf = tmp_path / "data" / corpus / f"{record_id}.pdf"
+    pdf.parent.mkdir(parents=True, exist_ok=True)
+    pdf.write_bytes(b"fake pdf")
+    return {"corpus": corpus, "record_id": record_id, "pdf_path": str(pdf)}
+
+
+def _mock_client(content: bytes = b"<tei/>") -> AsyncMock:
+    mock_response = MagicMock()
+    mock_response.content = content
+    mock_response.raise_for_status = MagicMock(return_value=None)
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.post = AsyncMock(return_value=mock_response)
+    return client
+
+
+def _mock_client_http_error(status_code: int = 500, body: str = "server error") -> AsyncMock:
+    error_response = MagicMock()
+    error_response.text = body
+    exc = httpx.HTTPStatusError(
+        f"Server error '{status_code}'",
+        request=MagicMock(),
+        response=error_response,
+    )
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock(side_effect=exc)
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.post = AsyncMock(return_value=mock_response)
+    return client
+
+
+class TestRunPredictAsync:
+    def _read_manifest(self, run_dir: Path) -> list:
+        path = run_dir / "predictions" / "manifest.jsonl"
+        if not path.exists():
+            return []
+        return [
+            json.loads(line) for line in path.read_text().splitlines() if line.strip()
+        ]
+
+    def test_successful_prediction_writes_file_and_manifest(self, tmp_path: Path):
+        records = [_make_record(tmp_path)]
+        run_dir = tmp_path / "run"
+        with patch("benchmarks.predict.httpx.AsyncClient", return_value=_mock_client(b"<tei/>")):
+            n_ok, n_err = asyncio.run(
+                _run_predict_async(records, set(), run_dir, "http://localhost:8080", 60, 1)
+            )
+        assert n_ok == 1 and n_err == 0
+        assert (run_dir / "predictions" / "biorxiv" / "doc1.tei.xml").read_bytes() == b"<tei/>"
+        entries = self._read_manifest(run_dir)
+        assert len(entries) == 1
+        assert entries[0]["status"] == "ok"
+        assert entries[0]["record_id"] == "doc1"
+
+    def test_http_error_records_error_and_body_in_manifest(self, tmp_path: Path):
+        records = [_make_record(tmp_path)]
+        run_dir = tmp_path / "run"
+        client = _mock_client_http_error(500, "traceback here")
+        with patch("benchmarks.predict.httpx.AsyncClient", return_value=client):
+            n_ok, n_err = asyncio.run(
+                _run_predict_async(records, set(), run_dir, "http://localhost:8080", 60, 1)
+            )
+        assert n_ok == 0 and n_err == 1
+        entries = self._read_manifest(run_dir)
+        assert entries[0]["status"] == "error"
+        assert entries[0]["error_body"] == "traceback here"
+
+    def test_already_done_records_are_skipped(self, tmp_path: Path):
+        records = [_make_record(tmp_path)]
+        run_dir = tmp_path / "run"
+        done = {("biorxiv", "doc1")}
+        with patch("benchmarks.predict.httpx.AsyncClient", return_value=_mock_client()):
+            n_ok, n_err = asyncio.run(
+                _run_predict_async(records, done, run_dir, "http://localhost:8080", 60, 1)
+            )
+        assert n_ok == 0 and n_err == 0
+        assert not (run_dir / "predictions" / "biorxiv" / "doc1.tei.xml").exists()
+
+    def test_multiple_records_all_processed(self, tmp_path: Path):
+        records = [
+            _make_record(tmp_path, "biorxiv", "doc1"),
+            _make_record(tmp_path, "biorxiv", "doc2"),
+            _make_record(tmp_path, "ore", "doc3"),
+        ]
+        run_dir = tmp_path / "run"
+        with patch("benchmarks.predict.httpx.AsyncClient", return_value=_mock_client(b"<tei/>")):
+            n_ok, n_err = asyncio.run(
+                _run_predict_async(records, set(), run_dir, "http://localhost:8080", 60, 2)
+            )
+        assert n_ok == 3 and n_err == 0
+
+    def test_generic_exception_records_error(self, tmp_path: Path):
+        records = [_make_record(tmp_path)]
+        run_dir = tmp_path / "run"
+        client = AsyncMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        client.post = AsyncMock(side_effect=Exception("connection refused"))
+        with patch("benchmarks.predict.httpx.AsyncClient", return_value=client):
+            n_ok, n_err = asyncio.run(
+                _run_predict_async(records, set(), run_dir, "http://localhost:8080", 60, 1)
+            )
+        assert n_ok == 0 and n_err == 1
+        entries = self._read_manifest(run_dir)
+        assert entries[0]["status"] == "error"
+        assert "connection refused" in entries[0]["error"]


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/96

Switches predict.py from sequential to async concurrent requests using httpx.AsyncClient + asyncio.Semaphore. Concurrency defaults to cpu_count (min 2) so CI and local runs scale automatically; override with BENCHMARK_CONCURRENCY=N. Each completed document now logs its position, latency, throughput, and estimated time remaining so long runs are observable. HTTP 500 responses include the server error body in both the log and manifest for easier diagnosis.