### PR TITLE
Fix medium mode counts to match validation split availability

### DIFF
--- a/benchmarks/eval.yml
+++ b/benchmarks/eval.yml
@@ -71,11 +71,11 @@ sampling:
     scielo_mx: 25
     scielo_preprints-jats: 25
   medium:
-    biorxiv: 50
+    biorxiv: 47
     ore: 50
     pkp: 50
     scielo_br: 50
-    scielo_mx: 50
+    scielo_mx: 34
     scielo_preprints-jats: 50
   large:
     biorxiv: 100


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/96

The validation split has fewer documents than the configured nominal for two corpora (biorxiv: 47, scielo_mx: 34 instead of 50 each), totalling 281 not 300. This caused the CI baseline check to always regenerate predictions — seeing EXISTING=281 < EXPECTED=300 even when predictions were fully up to date.