### PR TITLE
Move trailing period outside <title> element in TEI output

### DIFF
--- a/sciencebeam_parser/document/semantic_document.py
+++ b/sciencebeam_parser/document/semantic_document.py
@@ -282,8 +282,9 @@ class SemanticCaption(SemanticSimpleContentWrapper):
     pass
 
 
+@dataclass
 class SemanticTitle(SemanticSimpleContentWrapper):
-    pass
+    trailing_text: str = ''
 
 
 class SemanticJournal(SemanticSimpleContentWrapper):

--- a/sciencebeam_parser/document/tei/document.py
+++ b/sciencebeam_parser/document/tei/document.py
@@ -85,14 +85,17 @@ class TeiDocument(TeiElementWrapper):
             TEI_E('title', title, level="a", type="main")
         )
 
-    def set_title_layout_block(self, title_block: LayoutBlock):
+    def set_title_layout_block(self, title_block: LayoutBlock, trailing_text: str = ''):
+        title_elem = TEI_E(
+            'title',
+            {'level': 'a', 'type': 'main'},
+            *iter_layout_block_tei_children(title_block)
+        )
+        if trailing_text:
+            title_elem.tail = trailing_text
         self.set_child_element_at(
             ['teiHeader', 'fileDesc', 'titleStmt'],
-            TEI_E(
-                'title',
-                {'level': 'a', 'type': 'main'},
-                *iter_layout_block_tei_children(title_block)
-            )
+            title_elem
         )
 
     def get_abstract(self) -> str:

--- a/sciencebeam_parser/document/tei_document.py
+++ b/sciencebeam_parser/document/tei_document.py
@@ -57,9 +57,12 @@ def get_tei_for_semantic_document(  # pylint: disable=too-many-branches, too-man
 
     stop_watch_recorder.start('front')
     LOGGER.info('generating tei document: front')
-    title_block = semantic_document.front.view_by_type(SemanticTitle).merged_block
-    if title_block:
-        tei_document.set_title_layout_block(title_block)
+    semantic_title = next(semantic_document.front.iter_by_type(SemanticTitle), None)
+    if semantic_title is not None and semantic_title.merged_block:
+        tei_document.set_title_layout_block(
+            semantic_title.merged_block,
+            trailing_text=semantic_title.trailing_text
+        )
 
     abstract_block = semantic_document.front.view_by_type(SemanticAbstract).merged_block
     if abstract_block:

--- a/sciencebeam_parser/models/header/extract.py
+++ b/sciencebeam_parser/models/header/extract.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import Iterable, Mapping, Optional, Tuple
+from typing import AbstractSet, Iterable, Mapping, Optional, Tuple
 
 from sciencebeam_parser.document.semantic_document import (
     SemanticContentWrapper,
@@ -12,11 +12,38 @@ from sciencebeam_parser.document.semantic_document import (
     SemanticRawAuthors,
     T_SemanticContentFactory
 )
-from sciencebeam_parser.document.layout_document import LayoutBlock, LayoutTokensText
+from sciencebeam_parser.document.layout_document import (
+    LayoutBlock,
+    LayoutLine,
+    LayoutTokensText
+)
 from sciencebeam_parser.models.extract import SimpleModelSemanticExtractor
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+TITLE_TRAILING_PUNCT_CHARS: AbstractSet[str] = {'.'}
+
+
+def _split_trailing_title_punct(
+    layout_block: LayoutBlock,
+) -> Tuple[LayoutBlock, str]:
+    """Strip a trailing punctuation token from the title layout block.
+
+    Returns the cleaned block and the stripped character (empty string if nothing stripped).
+    GROBID moves such punctuation outside the <title> element via cleanField.
+    """
+    lines = layout_block.lines
+    if not lines:
+        return layout_block, ''
+    last_line = lines[-1]
+    tokens = last_line.tokens
+    if not tokens or tokens[-1].text not in TITLE_TRAILING_PUNCT_CHARS:
+        return layout_block, ''
+    trailing = tokens[-1].text
+    new_lines = lines[:-1] + [LayoutLine(tokens=tokens[:-1])]
+    return LayoutBlock(lines=new_lines), trailing
 
 
 # based on:
@@ -76,7 +103,8 @@ class HeaderSemanticExtractor(SimpleModelSemanticExtractor):
             previous_label = next_previous_label
             next_previous_label = name
             if name == '<title>' and not has_title:
-                yield SemanticTitle(layout_block=layout_block)
+                clean_block, trailing = _split_trailing_title_punct(layout_block)
+                yield SemanticTitle(layout_block=clean_block, trailing_text=trailing)
                 has_title = True
                 continue
             if name == '<abstract>' and not has_abstract:

--- a/tests/document/tei/document_test.py
+++ b/tests/document/tei/document_test.py
@@ -63,3 +63,16 @@ class TestTeiDocument:
             './tei:hi[@rend="italic"]'
         ) == ['italic1']
         assert document.get_title() == 'rend italic1 test'
+
+    def test_should_place_trailing_text_outside_title_element(self):
+        title_block = LayoutBlock.for_text('The title')
+        document = TeiDocument()
+        document.set_title_layout_block(title_block, trailing_text='.')
+        nodes = document.root.xpath(
+            '//tei:fileDesc/tei:titleStmt/tei:title[@level="a"][@type="main"]',
+            namespaces=TEI_NS_MAP
+        )
+        assert len(nodes) == 1
+        title_node = nodes[0]
+        assert document.get_title() == 'The title'
+        assert title_node.tail == '.'

--- a/tests/models/header/extract_test.py
+++ b/tests/models/header/extract_test.py
@@ -14,6 +14,7 @@ from sciencebeam_parser.document.layout_document import (
 
 from sciencebeam_parser.models.header.extract import (
     HeaderSemanticExtractor,
+    _split_trailing_title_punct,
     get_cleaned_abstract_text,
     get_cleaned_abstract_layout_block
 )
@@ -86,6 +87,26 @@ class TestGetCleanedAbstractLayoutBlock:
         assert join_layout_tokens(cleaned_layout_block.lines[0].tokens) == ABSTRACT_1
 
 
+class TestSplitTrailingTitlePunct:
+    def test_no_trailing_punct_returns_unchanged(self):
+        block = LayoutBlock.for_text(TITLE_1)
+        clean, trailing = _split_trailing_title_punct(block)
+        assert join_layout_tokens(clean.lines[0].tokens) == TITLE_1
+        assert trailing == ''
+
+    def test_trailing_dot_is_stripped_and_returned(self):
+        block = LayoutBlock.for_text(TITLE_1 + ' .')
+        clean, trailing = _split_trailing_title_punct(block)
+        assert join_layout_tokens(clean.lines[0].tokens) == TITLE_1
+        assert trailing == '.'
+
+    def test_empty_block_returns_unchanged(self):
+        block = LayoutBlock(lines=[])
+        clean, trailing = _split_trailing_title_punct(block)
+        assert clean == block
+        assert trailing == ''
+
+
 class TestHeaderSemanticExtractor:
     def test_should_set_title_and_abstract(self):
         semantic_content_list = list(
@@ -98,6 +119,18 @@ class TestHeaderSemanticExtractor:
         LOGGER.debug('front: %s', front)
         assert front.get_text_by_type(SemanticTitle) == TITLE_1
         assert front.get_text_by_type(SemanticAbstract) == ABSTRACT_1
+
+    def test_should_strip_trailing_dot_from_title_into_trailing_text(self):
+        title_with_dot = TITLE_1 + ' .'
+        semantic_content_list = list(
+            HeaderSemanticExtractor().iter_semantic_content_for_entity_blocks([
+                ('<title>', LayoutBlock.for_text(title_with_dot))
+            ])
+        )
+        front = SemanticFront(semantic_content_list)
+        semantic_title = next(front.iter_by_type(SemanticTitle))
+        assert front.get_text_by_type(SemanticTitle) == TITLE_1
+        assert semantic_title.trailing_text == '.'
 
     def test_should_ignore_additional_title_and_abstract(self):
         # Note: this behaviour should be reviewed


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/88

Academic paper titles occasionally end with a sentence-ending period that is present in the PDF but not considered part of the title proper (GROBID removes it via cleanField). Stripping it entirely loses information; leaving it inside <title> lowers benchmark scores.

Strip the trailing period at the header model's semantic extraction layer — where content decisions belong — and carry it in a new `trailing_text` field on `SemanticTitle`. The TEI renderer then places it as the lxml `.tail` of the `<title>` element so it appears in the XML after `</title>` rather than inside it. The title text content is clean for downstream consumers; nothing is discarded from the document.

Only a trailing `.` is stripped. The `_split_trailing_title_punct` helper checks the last layout token of the block; if its text is not in the stripped-char set it leaves the block untouched.