### PR TITLE
Include raw affiliations and citations in GROBID output

### DIFF
--- a/benchmarks/predict.py
+++ b/benchmarks/predict.py
@@ -127,6 +127,10 @@ async def _run_predict_async(
                     pdf_bytes = Path(rec["pdf_path"]).read_bytes()
                     response = await client.post(
                         f"{parser_url}{CONVERT_ENDPOINT}",
+                        data={
+                            "includeRawAffiliations": "1",
+                            "includeRawCitations": "1",
+                        },
                         files={
                             "input": (
                                 Path(rec["pdf_path"]).name,


### PR DESCRIPTION
This is so that we can see corresponding scores for GROBID.