### PR TITLE
Fix relative_page/document_position to match GROBID block token count

### DIFF
--- a/sciencebeam_parser/models/segmentation/data.py
+++ b/sciencebeam_parser/models/segmentation/data.py
@@ -163,6 +163,7 @@ def get_text_pattern(text: str) -> str:
 def count_block_tokens_like_grobid(block_lines: List[LayoutLine]) -> int:
     # Approximate Grobid's block.getTokens().size():
     # - each ALTO String is sub-tokenized via GrobidAnalyzer (same delimiters as our tokenizer)
+    # - PDFALTOSaxHandler appends a ' ' LayoutToken after each ALTO String
     # - endTextLine appends a '\n' LayoutToken per line
     # - endTextBlock appends a '\n' LayoutToken per block
     content_count = sum(
@@ -170,8 +171,21 @@ def count_block_tokens_like_grobid(block_lines: List[LayoutLine]) -> int:
         for line in block_lines
         for token in line.tokens
     )
+    # One space token per ALTO String: GROBID's PDFALTOSaxHandler adds a ' ' LayoutToken after
+    # each ALTO String, skipping it when the last sub-token ends with '-' (hyphenated endings).
+    # After normalize_layout_document() retokenization, ALTO String sub-tokens become separate
+    # LayoutTokens: internal sub-tokens get whitespace='', the last retains the original whitespace
+    # (' '). Pre-retokenization each ALTO String LayoutToken has default whitespace=' '. So
+    # token.whitespace identifies ALTO String boundaries in both cases, and token.text.endswith('-')
+    # detects hyphenation (equivalent to checking the last sub-token of the original ALTO String).
+    space_count = sum(
+        1
+        for line in block_lines
+        for token in line.tokens
+        if token.whitespace and not token.text.endswith('-')
+    )
     newline_count = len(block_lines) + 1  # one per TextLine + one per TextBlock
-    return content_count + newline_count
+    return content_count + space_count + newline_count
 
 
 class SegmentationLineFeatures(ContextAwareLayoutTokenFeatures):
@@ -245,9 +259,12 @@ class SegmentationLineFeatures(ContextAwareLayoutTokenFeatures):
         return get_str_bool_feature_value(self.is_bitmap_around)
 
     def get_str_block_relative_line_length_feature(self) -> str:
+        # GROBID adds a trailing space after each ALTO String in block.getText(),
+        # making every line length 1 char more than sbeam's join_layout_tokens.
+        # Adding 1 to both numerator and denominator matches GROBID's scaling.
         return str(feature_linear_scaling_int(
-            len(self.line_text),
-            self.max_block_line_text_length,
+            len(self.line_text) + 1,
+            self.max_block_line_text_length + 1,
             _LINESCALE
         ))
 

--- a/tests/models/segmentation/data_test.py
+++ b/tests/models/segmentation/data_test.py
@@ -10,7 +10,8 @@ from sciencebeam_parser.document.layout_document import (
     LayoutLine,
     LayoutPage,
     LayoutPageCoordinates,
-    LayoutPageMeta
+    LayoutPageMeta,
+    LayoutToken
 )
 
 from sciencebeam_parser.models.data import DEFAULT_DOCUMENT_FEATURES_CONTEXT
@@ -20,6 +21,7 @@ from sciencebeam_parser.models.segmentation.data import (
     SegmentationLineFeatures,
     SegmentationLineFeaturesProvider,
     calculate_page_main_areas,
+    count_block_tokens_like_grobid,
     get_text_pattern
 )
 
@@ -50,6 +52,41 @@ class TestGetTextPattern:
 
     def test_should_remove_digits(self):
         assert get_text_pattern('abc123') == 'abc'
+
+
+class TestCountBlockTokensLikeGrobid:
+    def test_should_count_subtokens_space_and_newlines(self):
+        # plain word: 1 sub-token + 1 space + 1 newline(line) + 1 newline(block) = 4
+        block_lines = [LayoutLine([LayoutToken('word')])]
+        assert count_block_tokens_like_grobid(block_lines) == 4
+
+    def test_should_not_count_space_for_hyphenated_line_ending(self):
+        # GROBID skips the space when the last sub-token of an ALTO String ends with '-'.
+        # Each ALTO <String> maps to ONE LayoutToken. 'treat-' → subtokens ['treat', '-'];
+        # last sub-token '-' ends with '-', so GROBID adds no trailing space.
+        # 1 LayoutToken → 2 sub-tokens + 0 spaces + 2 newlines = 4.
+        block_lines = [LayoutLine([LayoutToken('treat-')])]
+        assert count_block_tokens_like_grobid(block_lines) == 4
+
+    def test_should_not_count_space_for_paren_chi_hyphen_token(self):
+        # Real-world case: '(Chi-' → subtokens ['(', 'Chi', '-']; last is '-', no space.
+        # 3 sub-tokens + 0 spaces + 2 newlines = 5.
+        block_lines = [LayoutLine([LayoutToken('(Chi-')])]
+        assert count_block_tokens_like_grobid(block_lines) == 5
+
+    def test_should_count_space_only_at_alto_string_boundaries_after_retokenize(self):
+        # After normalize_layout_document() retokenization, an ALTO String like '(Chi-' splits
+        # into sub-tokens ['(', 'Chi', '-'] as separate LayoutTokens. Internal sub-tokens get
+        # whitespace='' (no boundary), the last retains the original whitespace (' ').
+        # '-' is the last sub-token of the ALTO String and ends with '-' → no space added.
+        # Result: 3 sub-tokens + 0 spaces + 2 newlines = 5 (same as pre-retokenize).
+        retokenized_subtokens = [
+            LayoutToken('(', whitespace=''),
+            LayoutToken('Chi', whitespace=''),
+            LayoutToken('-', whitespace=' '),
+        ]
+        block_lines = [LayoutLine(retokenized_subtokens)]
+        assert count_block_tokens_like_grobid(block_lines) == 5
 
 
 def _iter_line_features(
@@ -253,15 +290,34 @@ class TestSegmentationLineFeaturesProvider:
         LOGGER.debug('feature_values: %r', feature_values)
         assert feature_values == [
             {
-                'str_block_relative_line_length_feature': '1',  # 1 * 10 / 10
+                'str_block_relative_line_length_feature': '1',  # (1+1) * 10 / (10+1)
             },
             {
-                'str_block_relative_line_length_feature': '2',  # 2 * 10 / 10
+                'str_block_relative_line_length_feature': '2',  # (2+1) * 10 / (10+1)
             },
             {
-                'str_block_relative_line_length_feature': '10',  # 10 * 10 / 10
+                'str_block_relative_line_length_feature': '10',  # (10+1) * 10 / (10+1)
             },
         ]
+
+    def test_should_provide_block_relative_line_length_with_trailing_space_correction(
+        self,
+        features_provider: SegmentationLineFeaturesProvider
+    ):
+        # GROBID appends a trailing space after each ALTO String in block.getText(),
+        # making every line 1 char longer than sbeam's join_layout_tokens.
+        # Without +1 correction: floor(4/41*10) = 0; with +1: floor(5/42*10) = 1.
+        layout_document = LayoutDocument(pages=[
+            LayoutPage(blocks=[LayoutBlock(lines=[
+                LayoutLine.for_text('a' * 41),  # max line
+                LayoutLine.for_text('doi:'),    # 4-char line near the 0/1 bin boundary
+            ])])
+        ])
+        feature_values = [
+            features.get_str_block_relative_line_length_feature()
+            for features in _iter_line_features(features_provider, layout_document)
+        ]
+        assert feature_values == ['10', '1']
 
     def test_should_provide_same_relative_document_token_position_for_all_lines_in_block(
         self,
@@ -289,7 +345,8 @@ class TestSegmentationLineFeaturesProvider:
         features_provider: SegmentationLineFeaturesProvider
     ):
         # Matches GROBID: with 12 single-token blocks, nn increments by
-        # count_block_tokens_like_grobid (= 3) per block, giving positions 0-11.
+        # count_block_tokens_like_grobid (= 4: 1 sub-token + 1 space + 2 newlines) per block,
+        # giving positions 0-11.
         layout_document = LayoutDocument(pages=[
             LayoutPage(
                 blocks=[


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/88

GROBID's block.getTokens().size() counts sub-tokens from each ALTO String, plus a trailing space LayoutToken after each ALTO String (skipped when the last sub-token ends with '-'), plus a newline per TextLine and per TextBlock.

count_block_tokens_like_grobid previously omitted the space tokens, causing page_token_count to be undercounted and relative positions to fall one bin short of GROBID's values.

Space counting uses token.whitespace as the ALTO String boundary marker so it works correctly both before and after normalize_layout_document() retokenization. After retokenization, internal sub-tokens have whitespace='' while the last sub-token of each ALTO String retains the original whitespace (' '), matching the pre-retokenization case where every ALTO String token has the default whitespace=' '.