### PR TITLE
Add feature diff summary and label transition breakdown to model data diff

### DIFF
--- a/sciencebeam_parser/utils/model_data_diff.py
+++ b/sciencebeam_parser/utils/model_data_diff.py
@@ -1,7 +1,8 @@
 import difflib
 import logging
+from collections import Counter
 from dataclasses import dataclass, field
-from typing import List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +30,7 @@ class ModelDataDiffResult:
     aligned_with_diffs_count: int
     sbeam_only_count: int
     grobid_only_count: int
+    feature_diff_counts: Dict[str, int] = field(default_factory=dict)
     aligned_diffs: List[AlignedTokenDiff] = field(default_factory=list)
     sbeam_only_tokens: List[Tuple[str, int]] = field(default_factory=list)
     grobid_only_tokens: List[Tuple[str, int]] = field(default_factory=list)
@@ -94,6 +96,7 @@ def diff_model_data(  # pylint: disable=too-many-locals
         grobid_only_count=0
     )
 
+    feature_counts: Counter = Counter()
     for opcode, s0, s1, g0, g1 in matcher.get_opcodes():
         if opcode == 'equal':
             for si, gi in zip(range(s0, s1), range(g0, g1)):
@@ -109,6 +112,8 @@ def diff_model_data(  # pylint: disable=too-many-locals
                         grobid_line_number=gi + 1,
                         feature_diffs=feature_diffs
                     ))
+                    for fd in feature_diffs:
+                        feature_counts[fd.feature_name] += 1
         if opcode in ('delete', 'replace'):
             for si in range(s0, s1):
                 result.sbeam_only_count += 1
@@ -118,6 +123,7 @@ def diff_model_data(  # pylint: disable=too-many-locals
                 result.grobid_only_count += 1
                 result.grobid_only_tokens.append((grobid_tokens[gi], gi + 1))
 
+    result.feature_diff_counts = dict(feature_counts)
     return result
 
 
@@ -134,6 +140,28 @@ def format_diff_result(diff_result: ModelDataDiffResult) -> str:
             f' grobid-only: {diff_result.grobid_only_count}'
         ),
     ]
+
+    counts = diff_result.feature_diff_counts
+    non_label = sorted(
+        ((name, n) for name, n in counts.items() if name != 'label'),
+        key=lambda x: -x[1]
+    )
+    label_count = counts.get('label', 0)
+    if non_label or label_count:
+        lines.append('')
+        lines.append('feature diffs by type:')
+        for name, n in non_label:
+            lines.append(f'  {name}: {n}')
+        lines.append(f'  label: {label_count}')
+        label_pairs: Counter = Counter()
+        for token_diff in diff_result.aligned_diffs:
+            for fd in token_diff.feature_diffs:
+                if fd.feature_name == 'label':
+                    label_pairs[(fd.grobid_value, fd.sbeam_value)] += 1
+        for (grobid_label, sbeam_label), n in label_pairs.most_common():
+            lines.append(
+                f'    {n}x {grobid_label} (grobid) → {sbeam_label} (sbeam)'
+            )
 
     detail_lines = []
     for token_diff in diff_result.aligned_diffs:

--- a/tests/utils/model_data_diff_test.py
+++ b/tests/utils/model_data_diff_test.py
@@ -157,3 +157,52 @@ class TestFormatModelDataDiff:
         assert '< sbeam-only' not in result
         assert '> grobid-only' not in result
         assert '→' not in result
+
+    def test_feature_summary_shows_counts_sorted_by_frequency(self):
+        # Two capitalisation diffs and one label diff → summary lists cap first, then label
+        sbeam = (
+            self._make_line('a', cap='INITCAP', label='B-body') + '\n'
+            + self._make_line('b', cap='INITCAP', label='I-header') + '\n'
+            + self._make_line('c', cap='ALLCAP', label='B-body')
+        )
+        grobid = (
+            self._make_line('a', cap='ALLCAP', label='B-body') + '\n'
+            + self._make_line('b', cap='ALLCAP', label='B-body') + '\n'
+            + self._make_line('c', cap='ALLCAP', label='B-body')
+        )
+        result = format_model_data_diff(sbeam, grobid, FEATURE_NAMES_2)
+        assert 'feature diffs by type:' in result
+        cap_pos = result.index('capitalisation: 2')
+        label_pos = result.index('label: 1')
+        assert cap_pos < label_pos
+
+    def test_feature_summary_always_shows_label_even_when_zero(self):
+        sbeam = self._make_line('tok', cap='INITCAP')
+        grobid = self._make_line('tok', cap='ALLCAP')
+        result = format_model_data_diff(sbeam, grobid, FEATURE_NAMES_2)
+        assert 'label: 0' in result
+
+    def test_no_feature_summary_when_no_diffs(self):
+        data = self._make_line('tok')
+        result = format_model_data_diff(data, data, FEATURE_NAMES_2)
+        assert 'feature diffs by type:' not in result
+
+    def test_label_pair_breakdown_shown_sorted_by_frequency(self):
+        # Three label diffs: two header→body and one header→I-body.
+        # header→body appears most often and should come first.
+        sbeam = (
+            self._make_line('a', label='B-body') + '\n'
+            + self._make_line('b', label='B-body') + '\n'
+            + self._make_line('c', label='I-body')
+        )
+        grobid = (
+            self._make_line('a', label='B-header') + '\n'
+            + self._make_line('b', label='B-header') + '\n'
+            + self._make_line('c', label='B-header')
+        )
+        result = format_model_data_diff(sbeam, grobid, FEATURE_NAMES_2)
+        assert '2x B-header (grobid) → B-body (sbeam)' in result
+        assert '1x B-header (grobid) → I-body (sbeam)' in result
+        two_pos = result.index('2x B-header')
+        one_pos = result.index('1x B-header')
+        assert two_pos < one_pos


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/88

format_diff_result now outputs a "feature diffs by type:" section at the top of the diff, listing each feature with its diff count sorted by frequency (label always shown last even when zero). Under the label count, each distinct grobid→sbeam label pair is listed with its frequency, e.g. "6x <header> (grobid) → <body> (sbeam)", sorted most-common first.