### PR TITLE
Fix reference segmenter feature data to match GROBID

### DIFF
--- a/sciencebeam_parser/models/data.py
+++ b/sciencebeam_parser/models/data.py
@@ -323,15 +323,24 @@ class RelativeFontSizeFeature:
 
 
 class LineIndentationStatusFeature:
-    def __init__(self, persist_across_blocks: bool = False):
+    def __init__(
+        self,
+        persist_across_blocks: bool = False,
+        compare_across_blocks: bool = False
+    ):
         self._persist_across_blocks = persist_across_blocks
+        self._compare_across_blocks = compare_across_blocks
         self._line_start_x: Optional[float] = None
         self._is_new_line = True
         self._is_indented = False
         self._skip_next_line_start_update = True
 
     def on_new_block(self):
-        if self._persist_across_blocks:
+        if self._compare_across_blocks:
+            # GROBID ReferenceSegmenterParser behaviour: no block-level reset; every new line
+            # (including the first line of a new block) compares against the previous line.
+            pass
+        elif self._persist_across_blocks:
             # GROBID HeaderParser behaviour: lineStartX persists across blocks.
             # previousFeatures=null at the block boundary suppresses the update for the
             # first line of the new block, so line 2 compares against the previous block's
@@ -555,7 +564,10 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
         max_concatenated_line_tokens_length: int = 0,
         line_token_position: int = 0,
         relative_font_size_feature: Optional[RelativeFontSizeFeature] = None,
-        line_indentation_status_feature: Optional[LineIndentationStatusFeature] = None
+        line_indentation_status_feature: Optional[LineIndentationStatusFeature] = None,
+        grobid_nn: int = 0,
+        grobid_line_length: int = 0,
+        max_grobid_line_length: int = 0
     ) -> None:
         super().__init__(layout_token)
         self.layout_line = layout_line
@@ -572,6 +584,9 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
         self.line_token_position = line_token_position
         self.relative_font_size_feature = relative_font_size_feature
         self.line_indentation_status_feature = line_indentation_status_feature
+        self.grobid_nn = grobid_nn
+        self.grobid_line_length = grobid_line_length
+        self.max_grobid_line_length = max_grobid_line_length
 
     def get_layout_model_data(self, features: List[str]) -> LayoutModelData:
         return LayoutModelData(
@@ -667,10 +682,10 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
         )
 
     def get_truncated_line_punctuation_profile_length_feature(self) -> str:
-        return get_punctuation_profile_length_for_raw_punctuation_profile_feature(
-            self.get_raw_line_punctuation_profile(),
-            max_length=10
-        )
+        raw = self.get_raw_line_punctuation_profile()
+        if not raw:
+            return 'no'
+        return str(min(10, len(raw)))
 
     def get_str_line_token_relative_position(self) -> str:
         return str(feature_linear_scaling_int(
@@ -683,6 +698,23 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
         return str(feature_linear_scaling_int(
             len(self.concatenated_line_tokens_text),
             self.max_concatenated_line_tokens_length,
+            _LINESCALE
+        ))
+
+    def get_str_grobid_line_token_relative_position(self) -> str:
+        # Matches GROBID's nn / currentLineLength formula:
+        # nn = cumulative length including current token, spaces double-counted;
+        # currentLineLength = full line length including whitespace and newline.
+        return str(feature_linear_scaling_int(
+            self.grobid_nn,
+            self.grobid_line_length,
+            _LINESCALE
+        ))
+
+    def get_str_grobid_line_relative_length(self) -> str:
+        return str(feature_linear_scaling_int(
+            self.grobid_line_length,
+            self.max_grobid_line_length,
             _LINESCALE
         ))
 
@@ -736,9 +768,18 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
     def get_str_is_month(self) -> str:
         return get_str_bool_feature_value(self.token_text.lower() in MONTH_NAMES)
 
+    def get_str_is_first_name_for_uppercase_lookup(self) -> str:
+        # GROBID's first-name list is all-uppercase; exact (case-sensitive) matching means
+        # only tokens that are themselves all-uppercase will hit an entry.
+        if not self.token_text.isupper():
+            return '0'
+        return self._get_str_lookup(
+            self.document_features_context.app_features_context.first_name_lookup
+        )
+
     def get_str_is_http(self) -> str:
         return get_str_bool_feature_value(
-            self.token_text.startswith(('http://', 'https://'))
+            self.token_text.lower().startswith('http')
         )
 
     def get_dummy_str_relative_document_position(self):
@@ -765,12 +806,14 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
     def __init__(
         self,
         document_features_context: DocumentFeaturesContext,
-        persist_indentation_reference_across_blocks: bool = False
+        persist_indentation_reference_across_blocks: bool = False,
+        compare_indentation_across_blocks: bool = False
     ):
         self.document_features_context = document_features_context
         self._persist_indentation_reference_across_blocks = (
             persist_indentation_reference_across_blocks
         )
+        self._compare_indentation_across_blocks = compare_indentation_across_blocks
         self._feature_defs: List[FeatureDef[ContextAwareLayoutTokenFeatures]] = []
 
     @property
@@ -793,7 +836,8 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
             layout_document.iter_all_tokens()
         )
         line_indentation_status_feature = LineIndentationStatusFeature(
-            persist_across_blocks=self._persist_indentation_reference_across_blocks
+            persist_across_blocks=self._persist_indentation_reference_across_blocks,
+            compare_across_blocks=self._compare_indentation_across_blocks
         )
         previous_layout_token: Optional[LayoutToken] = None
         concatenated_line_tokens_length_by_line_id = {
@@ -807,6 +851,16 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
         max_concatenated_line_tokens_length = max(
             concatenated_line_tokens_length_by_line_id.values()
         )
+        # GROBID-compatible line lengths: include inter-token whitespace and a newline,
+        # matching GROBID's accumulated.length() in its look-ahead (nn / currentLineLength).
+        grobid_line_length_by_line_id = {
+            id(line): (
+                sum(len(t.text) + (1 if t.whitespace else 0) for t in line.tokens) + 1
+            )
+            for block in layout_document.iter_all_blocks()
+            for line in block.lines
+        }
+        max_grobid_line_length = max(grobid_line_length_by_line_id.values())
         document_token_count = sum((
             1
             for _ in layout_document.iter_all_tokens()
@@ -824,7 +878,11 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
                     token.text for token in line_tokens
                 ])
                 line_token_position = 0
+                grobid_nn = 0
+                grobid_line_length = grobid_line_length_by_line_id[id(line)]
                 for token_index, token in enumerate(line_tokens):
+                    # GROBID's nn includes the current token's length before the feature is emitted.
+                    grobid_nn += len(token.text)
                     yield from self.iter_model_data_for_context_layout_token_features(
                         ContextAwareLayoutTokenFeatures(
                             token,
@@ -841,9 +899,15 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
                             max_concatenated_line_tokens_length=max_concatenated_line_tokens_length,
                             line_token_position=line_token_position,
                             relative_font_size_feature=relative_font_size_feature,
-                            line_indentation_status_feature=line_indentation_status_feature
+                            line_indentation_status_feature=line_indentation_status_feature,
+                            grobid_nn=grobid_nn,
+                            grobid_line_length=grobid_line_length,
+                            max_grobid_line_length=max_grobid_line_length
                         )
                     )
                     previous_layout_token = token
                     line_token_position += len(token.text)
+                    # GROBID double-counts each space: space token contributes len(' ')+1 = 2.
+                    if token.whitespace:
+                        grobid_nn += 2 * len(token.whitespace)
                     document_token_index += 1

--- a/sciencebeam_parser/models/reference_segmenter/data.py
+++ b/sciencebeam_parser/models/reference_segmenter/data.py
@@ -4,13 +4,14 @@ from sciencebeam_parser.models.data import (
     ContextAwareLayoutTokenFeatures,
     ContextAwareLayoutTokenModelDataGenerator,
     DocumentFeaturesContext,
-    FeatureDef
+    FeatureDef,
+    get_punctuation_type_feature
 )
 
 
 class ReferenceSegmenterDataGenerator(ContextAwareLayoutTokenModelDataGenerator):
     def __init__(self, document_features_context: DocumentFeaturesContext):
-        super().__init__(document_features_context)
+        super().__init__(document_features_context, compare_indentation_across_blocks=True)
         self._feature_defs: List[FeatureDef[ContextAwareLayoutTokenFeatures]] = [
             FeatureDef('token_text', lambda f: f.token_text),
             FeatureDef('lower_token_text', lambda f: f.get_lower_token_text()),
@@ -23,29 +24,30 @@ class ReferenceSegmenterDataGenerator(ContextAwareLayoutTokenModelDataGenerator)
             FeatureDef('suffix_3', lambda f: f.get_suffix(3)),
             FeatureDef('suffix_4', lambda f: f.get_suffix(4)),
             FeatureDef('line_status',
-                       lambda f: f.get_line_status_with_lineend_for_single_token()),
+                       lambda f: f.get_line_status_with_linestart_for_single_token()),
             FeatureDef('alignment', lambda f: f.get_alignment_status()),
             FeatureDef('capitalisation',
                        lambda f: f.get_capitalisation_status_using_allcap()),
             FeatureDef('digit_status',
                        lambda f: f.get_digit_status_using_containsdigits()),
             FeatureDef('is_single_char', lambda f: f.get_str_is_single_char()),
-            FeatureDef('is_proper_name', lambda f: f.get_dummy_str_is_proper_name()),
-            FeatureDef('is_common_name', lambda f: f.get_dummy_str_is_common_name()),
-            FeatureDef('is_first_name', lambda f: f.get_str_is_first_name()),
+            FeatureDef('is_proper_name', lambda f: f.get_str_is_proper_name()),
+            FeatureDef('is_common_name', lambda f: f.get_str_is_common_name()),
+            FeatureDef('is_first_name',
+                       lambda f: f.get_str_is_first_name_for_uppercase_lookup()),
             FeatureDef('is_location_name',
                        lambda f: f.get_dummy_str_is_location_name()),
-            FeatureDef('is_year', lambda f: f.get_dummy_str_is_year()),
-            FeatureDef('is_month', lambda f: f.get_dummy_str_is_month()),
+            FeatureDef('is_year', lambda f: f.get_str_is_year()),
+            FeatureDef('is_month', lambda f: f.get_str_is_month()),
             FeatureDef('is_http', lambda f: f.get_str_is_http()),
             FeatureDef('punctuation_profile',
-                       lambda f: f.get_line_punctuation_profile()),
+                       lambda f: get_punctuation_type_feature(f.token_text)),
             FeatureDef('line_token_relative_position',
-                       lambda f: f.get_str_line_token_relative_position()),
+                       lambda f: f.get_str_grobid_line_token_relative_position()),
             FeatureDef('line_relative_length',
-                       lambda f: f.get_str_line_relative_length()),
+                       lambda f: f.get_str_grobid_line_relative_length()),
             FeatureDef('block_status',
-                       lambda f: f.get_block_status_with_blockend_for_single_token()),
+                       lambda f: f.get_block_status_with_blockstart_for_single_token()),
             FeatureDef('truncated_punctuation_profile_length',
                        lambda f: f.get_truncated_line_punctuation_profile_length_feature()),
             FeatureDef('dummy_label', lambda f: f.get_dummy_label()),

--- a/tests/models/data_test.py
+++ b/tests/models/data_test.py
@@ -150,6 +150,51 @@ class TestLineIndentationStatusFeature:
         ) is True
 
 
+class TestLineIndentationStatusFeatureWithCompareAcrossBlocks:
+    """Tests for compare_across_blocks=True (GROBID ReferenceSegmenterParser behaviour).
+
+    Every line (including the first of a new block) compares its x against the previous
+    line's x, matching GROBID's flat-token-stream processing where blocks have no effect.
+    """
+
+    def _feature(self):
+        return LineIndentationStatusFeature(compare_across_blocks=True)
+
+    def test_first_line_of_new_block_resets_indentation_when_shifted_left(self):
+        # Block 1: line at x=10, then indented line at x=50 → _is_indented=True
+        # Block 2: line at x=10 — should RESET indentation (x=10 < x=50 - charWidth)
+        f = self._feature()
+        f.on_new_block()
+        f.on_new_line()
+        assert f.get_is_indented_and_update(
+            LayoutToken('x', coordinates=LayoutPageCoordinates(x=10, y=10, width=10, height=10))
+        ) is False
+        f.on_new_line()
+        assert f.get_is_indented_and_update(
+            LayoutToken('x', coordinates=LayoutPageCoordinates(x=50, y=10, width=10, height=10))
+        ) is True
+        # New block at x=10 — SHOULD reset indented (cross-block comparison happens)
+        f.on_new_block()
+        f.on_new_line()
+        assert f.get_is_indented_and_update(
+            LayoutToken('x', coordinates=LayoutPageCoordinates(x=10, y=10, width=10, height=10))
+        ) is False
+
+    def test_first_line_of_new_block_sets_indentation_when_shifted_right(self):
+        f = self._feature()
+        f.on_new_block()
+        f.on_new_line()
+        assert f.get_is_indented_and_update(
+            LayoutToken('x', coordinates=LayoutPageCoordinates(x=10, y=10, width=10, height=10))
+        ) is False
+        # New block indented right of x=10
+        f.on_new_block()
+        f.on_new_line()
+        assert f.get_is_indented_and_update(
+            LayoutToken('x', coordinates=LayoutPageCoordinates(x=50, y=10, width=10, height=10))
+        ) is True
+
+
 class TestLineIndentationStatusFeatureWithPersistAcrossBlocks:
     """Tests for persist_across_blocks=True (GROBID HeaderParser behaviour).
 

--- a/tests/models/reference_segmenter/data_test.py
+++ b/tests/models/reference_segmenter/data_test.py
@@ -1,0 +1,246 @@
+from sciencebeam_parser.document.layout_document import (
+    LayoutBlock,
+    LayoutDocument,
+    LayoutLine,
+    LayoutPageCoordinates,
+    LayoutToken
+)
+from sciencebeam_parser.lookup import SimpleTextLookUp
+from sciencebeam_parser.models.data import (
+    AppFeaturesContext,
+    DEFAULT_DOCUMENT_FEATURES_CONTEXT,
+    DocumentFeaturesContext
+)
+from sciencebeam_parser.models.reference_segmenter.data import ReferenceSegmenterDataGenerator
+
+
+def _make_features_context_with_names(first_names):
+    lookup = SimpleTextLookUp(set(first_names))
+    return DocumentFeaturesContext(
+        app_features_context=AppFeaturesContext(first_name_lookup=lookup)
+    )
+
+
+def _get_feature(token_text: str, feature_name: str, line_tokens=None) -> str:
+    if line_tokens is None:
+        line_tokens = [LayoutToken(token_text)]
+    line = LayoutLine(line_tokens)
+    doc = LayoutDocument.for_blocks([LayoutBlock(lines=[line])])
+    gen = ReferenceSegmenterDataGenerator(DEFAULT_DOCUMENT_FEATURES_CONTEXT)
+    data_list = list(gen.iter_model_data_for_layout_document(doc))
+    # find the entry for the requested token
+    for item in data_list:
+        if item.data_line and item.data_line.split()[0] == token_text:
+            cols = item.data_line.split()
+            idx = gen.feature_names.index(feature_name)
+            return cols[idx]
+    raise KeyError(f'token {token_text!r} not found')
+
+
+class TestLineStatus:
+    def test_single_token_line_gives_linestart(self):
+        feature = _get_feature('word', 'line_status')
+        assert feature == 'LINESTART'
+
+    def test_first_token_of_multi_token_line_gives_linestart(self):
+        tokens = [LayoutToken('first', whitespace=' '), LayoutToken('second')]
+        feature = _get_feature('first', 'line_status', line_tokens=tokens)
+        assert feature == 'LINESTART'
+
+    def test_last_token_of_multi_token_line_gives_lineend(self):
+        tokens = [LayoutToken('first', whitespace=' '), LayoutToken('second')]
+        feature = _get_feature('second', 'line_status', line_tokens=tokens)
+        assert feature == 'LINEEND'
+
+    def test_middle_token_gives_linein(self):
+        tokens = [
+            LayoutToken('a', whitespace=' '),
+            LayoutToken('b', whitespace=' '),
+            LayoutToken('c')
+        ]
+        feature = _get_feature('b', 'line_status', line_tokens=tokens)
+        assert feature == 'LINEIN'
+
+
+class TestBlockStatus:
+    def test_single_token_single_line_block_gives_blockstart(self):
+        feature = _get_feature('word', 'block_status')
+        assert feature == 'BLOCKSTART'
+
+
+class TestPunctuationProfile:
+    def test_plain_word_gives_nopunct(self):
+        assert _get_feature('hello', 'punctuation_profile') == 'NOPUNCT'
+
+    def test_dot_gives_dot(self):
+        assert _get_feature('.', 'punctuation_profile') == 'DOT'
+
+    def test_comma_gives_comma(self):
+        assert _get_feature(',', 'punctuation_profile') == 'COMMA'
+
+    def test_hyphen_gives_hyphen(self):
+        assert _get_feature('-', 'punctuation_profile') == 'HYPHEN'
+
+    def test_open_bracket_gives_openbracket(self):
+        assert _get_feature('(', 'punctuation_profile') == 'OPENBRACKET'
+
+    def test_close_bracket_gives_endbracket(self):
+        assert _get_feature(')', 'punctuation_profile') == 'ENDBRACKET'
+
+
+class TestTruncatedPunctuationProfileLength:
+    def test_no_punctuation_on_line_gives_no(self):
+        assert _get_feature('word', 'truncated_punctuation_profile_length') == 'no'
+
+    def test_line_with_punctuation_gives_count(self):
+        tokens = [
+            LayoutToken('word', whitespace=' '),
+            LayoutToken('.', whitespace=' '),
+            LayoutToken('end')
+        ]
+        assert _get_feature(
+            'word', 'truncated_punctuation_profile_length', line_tokens=tokens
+        ) == '1'
+
+
+class TestIsYear:
+    def test_four_digit_year_gives_1(self):
+        assert _get_feature('2020', 'is_year') == '1'
+
+    def test_word_gives_0(self):
+        assert _get_feature('word', 'is_year') == '0'
+
+
+class TestIsMonth:
+    def test_january_gives_1(self):
+        assert _get_feature('january', 'is_month') == '1'
+
+    def test_word_gives_0(self):
+        assert _get_feature('word', 'is_month') == '0'
+
+
+class TestIsHttp:
+    def test_full_url_gives_1(self):
+        assert _get_feature('https://doi.org/10.1234', 'is_http') == '1'
+
+    def test_standalone_https_gives_1(self):
+        assert _get_feature('https', 'is_http') == '1'
+
+    def test_standalone_http_gives_1(self):
+        assert _get_feature('http', 'is_http') == '1'
+
+    def test_word_gives_0(self):
+        assert _get_feature('word', 'is_http') == '0'
+
+
+class TestIsFirstName:
+    def test_all_caps_name_gives_1_when_in_lookup(self):
+        # GROBID's first-name list uses all-uppercase entries; only all-uppercase tokens match
+        ctx = _make_features_context_with_names({'AL'})
+        tokens = [LayoutToken('AL')]
+        line = LayoutLine(tokens)
+        doc = LayoutDocument.for_blocks([LayoutBlock(lines=[line])])
+        gen = ReferenceSegmenterDataGenerator(ctx)
+        item = next(gen.iter_model_data_for_layout_document(doc))
+        idx = gen.feature_names.index('is_first_name')
+        assert item.data_line.split()[idx] == '1'
+
+    def test_lowercase_common_abbreviation_gives_0(self):
+        # 'al' (as in 'et al.') must NOT match even though 'AL' is in the lookup
+        ctx = _make_features_context_with_names({'AL'})
+        tokens = [LayoutToken('al')]
+        line = LayoutLine(tokens)
+        doc = LayoutDocument.for_blocks([LayoutBlock(lines=[line])])
+        gen = ReferenceSegmenterDataGenerator(ctx)
+        item = next(gen.iter_model_data_for_layout_document(doc))
+        idx = gen.feature_names.index('is_first_name')
+        assert item.data_line.split()[idx] == '0'
+
+    def test_mixed_case_gives_0(self):
+        # 'Marine' must not match 'MARINE' in the lookup
+        ctx = _make_features_context_with_names({'MARINE'})
+        tokens = [LayoutToken('Marine')]
+        line = LayoutLine(tokens)
+        doc = LayoutDocument.for_blocks([LayoutBlock(lines=[line])])
+        gen = ReferenceSegmenterDataGenerator(ctx)
+        item = next(gen.iter_model_data_for_layout_document(doc))
+        idx = gen.feature_names.index('is_first_name')
+        assert item.data_line.split()[idx] == '0'
+
+
+class TestAlignment:
+    def test_reference_number_line_after_indented_continuation_is_alignedleft(self):
+        # References are: "1 Author ..."  (number at x=10, continuation at x=50).
+        # The next reference number line (x=10) should be ALIGNEDLEFT, not LINEINDENT.
+        # This matches GROBID's reference segmenter which compares every line
+        # against the immediately preceding line across block boundaries.
+        block1_lines = [
+            LayoutLine([LayoutToken(
+                '1', whitespace=' ',
+                coordinates=LayoutPageCoordinates(x=10, y=10, width=10, height=10)
+            )]),
+            LayoutLine([LayoutToken(
+                'Author', whitespace=' ',
+                coordinates=LayoutPageCoordinates(x=50, y=20, width=30, height=10)
+            )]),
+        ]
+        block2_lines = [
+            LayoutLine([LayoutToken(
+                '2', whitespace=' ',
+                coordinates=LayoutPageCoordinates(x=10, y=30, width=10, height=10)
+            )]),
+        ]
+        doc = LayoutDocument.for_blocks([
+            LayoutBlock(lines=block1_lines),
+            LayoutBlock(lines=block2_lines),
+        ])
+        gen = ReferenceSegmenterDataGenerator(DEFAULT_DOCUMENT_FEATURES_CONTEXT)
+        items = list(gen.iter_model_data_for_layout_document(doc))
+        idx = gen.feature_names.index('alignment')
+        alignments = [item.data_line.split()[idx] for item in items]
+        # token '1': ALIGNEDLEFT (first line, no previous)
+        assert alignments[0] == 'ALIGNEDLEFT'
+        # token 'Author': LINEINDENT (indented relative to '1')
+        assert alignments[1] == 'LINEINDENT'
+        # token '2': ALIGNEDLEFT (x=10 < x=50 of previous 'Author' line → not indented)
+        assert alignments[2] == 'ALIGNEDLEFT'
+
+
+class TestLineTokenRelativePosition:
+    def test_single_token_line_includes_token_length_in_numerator(self):
+        # GROBID: nn = text.length() for LINESTART token; currentLineLength includes whitespace+\n.
+        # Single token "9" with trailing space: nn=1, cl=3 ("9 \n") → floor(1/3*10) = 3
+        tokens = [LayoutToken('9', whitespace=' ')]
+        assert _get_feature('9', 'line_token_relative_position', line_tokens=tokens) == '3'
+
+    def test_single_token_references_heading(self):
+        # "References" (10 chars) with trailing space: nn=10, cl=12 → floor(10/12*10) = 8
+        tokens = [LayoutToken('References', whitespace=' ')]
+        assert _get_feature(
+            'References', 'line_token_relative_position', line_tokens=tokens
+        ) == '8'
+
+    def test_first_token_of_long_line_gives_small_value(self):
+        # "Razavi" at start of a line with many more tokens → near 0
+        # Build a line where total grobid_cl >> 6 (len "Razavi")
+        long_line = [LayoutToken('Razavi', whitespace=' ')] + [
+            LayoutToken('x', whitespace=' ') for _ in range(30)
+        ]
+        feature = _get_feature('Razavi', 'line_token_relative_position', line_tokens=long_line)
+        assert feature == '0'
+
+
+class TestLineRelativeLength:
+    def test_single_token_line_is_shorter_than_long_line(self):
+        # Short line ("9 ") vs long line should give a small relative length
+        doc_lines = [
+            LayoutLine([LayoutToken('9', whitespace=' ')]),
+            LayoutLine([LayoutToken('x', whitespace=' ')] * 20),
+        ]
+        doc = LayoutDocument.for_blocks([LayoutBlock(lines=doc_lines)])
+        gen = ReferenceSegmenterDataGenerator(DEFAULT_DOCUMENT_FEATURES_CONTEXT)
+        items = list(gen.iter_model_data_for_layout_document(doc))
+        idx = gen.feature_names.index('line_relative_length')
+        short_val = int(items[0].data_line.split()[idx])
+        long_val = int(items[-1].data_line.split()[idx])
+        assert short_val < long_val


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/88

Three feature computation fixes that reduce label differences vs GROBID on document 10.1101_2020.11.29.402842 from 46 to 1.

line_token_relative_position / line_relative_length: GROBID's nn accumulates each token's length (including the current token before the feature is emitted) and double-counts inter-token spaces (each space contributes len(' ') + 1 = 2). The denominator (currentLineLength) includes all inter-token whitespace and a trailing newline. Add grobid_nn, grobid_line_length and max_grobid_line_length fields to ContextAwareLayoutTokenFeatures, computed in the generator loop, and use them in the reference segmenter's feature defs.

alignment:
GROBID's ReferenceSegmenterParser processes tokens as a flat stream with no block-level reset: every new line's x is compared against the previous line's x, even across block boundaries. sbeam's LineIndentationStatusFeature was skipping that comparison for the first line of each new block, leaving the previous block's _is_indented state unchanged when it should have been cleared. Add compare_across_blocks=True mode (on_new_block is a no-op) to LineIndentationStatusFeature and enable it in ReferenceSegmenterDataGenerator.