### PR TITLE
Fix alignment double-skip and is_common_name case handling for reference segmenter

### DIFF
--- a/sciencebeam_parser/lookup/loader.py
+++ b/sciencebeam_parser/lookup/loader.py
@@ -34,12 +34,15 @@ def load_lookup_from_text_file(path: str, split_on_hyphen: bool = False) -> Text
 
 
 def load_lookup_from_wf_file(path: str) -> TextLookUp:
-    # GROBID multext wordforms format: first tab-separated column is the word form
+    # GROBID multext wordforms format: first tab-separated column is the word form.
+    # GROBID stores words as-is (preserving case) but test_common() lowercases the query,
+    # so capitalised wordforms (e.g. 'British', 'October') are effectively unreachable.
+    # We replicate this by only storing already-lowercase wordforms.
     words: set = set()
     for line in Path(path).read_text(encoding='latin-1').splitlines():
         if line:
             word = line.split('\t', 1)[0]
-            if word:
+            if word and word == word.lower():
                 words.add(word)
     return SimpleTextLookUp(words)
 

--- a/sciencebeam_parser/models/data.py
+++ b/sciencebeam_parser/models/data.py
@@ -334,6 +334,10 @@ class LineIndentationStatusFeature:
         self._is_new_line = True
         self._is_indented = False
         self._skip_next_line_start_update = True
+        # For compare_across_blocks: skip the very first LINESTART update so that
+        # token 2 compares against token 2's predecessor (token 2), not token 1.
+        # This matches GROBID's previousFeatures=null double-skip behaviour.
+        self._first_linestart_skipped = False
 
     def on_new_block(self):
         if self._compare_across_blocks:
@@ -354,7 +358,12 @@ class LineIndentationStatusFeature:
 
     def get_is_indented_and_update(self, layout_token: LayoutToken):
         if self._is_new_line and layout_token.coordinates and layout_token.text:
-            if self._persist_across_blocks and self._skip_next_line_start_update:
+            if self._compare_across_blocks and not self._first_linestart_skipped:
+                # Match GROBID: the first-ever LINESTART token does not set lineStartX
+                # (previousFeatures=null), so token 2 also skips comparison (NaN check).
+                # Only from token 3 onward does comparison happen normally.
+                self._first_linestart_skipped = True
+            elif self._persist_across_blocks and self._skip_next_line_start_update:
                 self._skip_next_line_start_update = False
             else:
                 previous_line_start_x = self._line_start_x

--- a/tests/lookup/loader_test.py
+++ b/tests/lookup/loader_test.py
@@ -37,12 +37,23 @@ class TestLoadLookupFromWfFile:
         assert lookup.contains('battery\t=\tNcns-') is False
         assert lookup.contains('battery') is True
 
-    def test_should_be_case_insensitive(self, tmp_path: Path):
+    def test_lowercase_word_matches_case_insensitively(self, tmp_path: Path):
+        # A word that is already lowercase in the file can be found regardless of query case.
+        wf_file = tmp_path / 'english.wf'
+        wf_file.write_text('innovation\t=\tNcns-\n', encoding='latin-1')
+        lookup = load_lookup_from_wf_file(str(wf_file))
+        assert lookup.contains('innovation') is True
+        assert lookup.contains('Innovation') is True
+
+    def test_capitalised_word_is_not_stored(self, tmp_path: Path):
+        # GROBID stores words as-is but queries in lowercase, so capitalised wordforms
+        # (e.g. 'British', 'October') are effectively unreachable.
+        # We replicate this by only storing already-lowercase wordforms.
         wf_file = tmp_path / 'english.wf'
         wf_file.write_text('Innovation\t=\tNcns-\n', encoding='latin-1')
         lookup = load_lookup_from_wf_file(str(wf_file))
-        assert lookup.contains('Innovation') is True
-        assert lookup.contains('innovation') is True
+        assert lookup.contains('Innovation') is False
+        assert lookup.contains('innovation') is False
 
     def test_should_load_multiple_word_forms(self, tmp_path: Path):
         wf_file = tmp_path / 'english.wf'

--- a/tests/models/data_test.py
+++ b/tests/models/data_test.py
@@ -153,46 +153,57 @@ class TestLineIndentationStatusFeature:
 class TestLineIndentationStatusFeatureWithCompareAcrossBlocks:
     """Tests for compare_across_blocks=True (GROBID ReferenceSegmenterParser behaviour).
 
-    Every line (including the first of a new block) compares its x against the previous
-    line's x, matching GROBID's flat-token-stream processing where blocks have no effect.
+    GROBID skips the first-ever LINESTART update (previousFeatures=null), so the second
+    LINESTART also skips comparison (previousLineStartX=NaN). Only from the third LINESTART
+    onward does normal comparison happen.  All block boundaries are ignored (no-op on_new_block).
     """
 
     def _feature(self):
         return LineIndentationStatusFeature(compare_across_blocks=True)
 
     def test_first_line_of_new_block_resets_indentation_when_shifted_left(self):
-        # Block 1: line at x=10, then indented line at x=50 → _is_indented=True
-        # Block 2: line at x=10 — should RESET indentation (x=10 < x=50 - charWidth)
+        # GROBID double-skip: line 1 skips update; line 2 skips comparison (stores reference).
+        # Line 3 (x=50) is the first real comparison: x=50 > x=10 → LINEINDENT.
+        # New block at x=10 — SHOULD reset indentation (cross-block comparison happens).
         f = self._feature()
         f.on_new_block()
         f.on_new_line()
         assert f.get_is_indented_and_update(
             LayoutToken('x', coordinates=LayoutPageCoordinates(x=10, y=10, width=10, height=10))
-        ) is False
+        ) is False  # line 1: first-ever skip, lineStartX not set
+        f.on_new_line()
+        assert f.get_is_indented_and_update(
+            LayoutToken('x', coordinates=LayoutPageCoordinates(x=10, y=10, width=10, height=10))
+        ) is False  # line 2: previous=None, no comparison, stores lineStartX=10
         f.on_new_line()
         assert f.get_is_indented_and_update(
             LayoutToken('x', coordinates=LayoutPageCoordinates(x=50, y=10, width=10, height=10))
-        ) is True
+        ) is True   # line 3: compare x=50 vs x=10 → LINEINDENT
         # New block at x=10 — SHOULD reset indented (cross-block comparison happens)
         f.on_new_block()
         f.on_new_line()
         assert f.get_is_indented_and_update(
             LayoutToken('x', coordinates=LayoutPageCoordinates(x=10, y=10, width=10, height=10))
-        ) is False
+        ) is False  # line 4 (new block): compare x=10 vs x=50 → ALIGNEDLEFT
 
     def test_first_line_of_new_block_sets_indentation_when_shifted_right(self):
+        # After the double-skip warm-up, a new block at x=50 (right of x=10) is LINEINDENT.
         f = self._feature()
         f.on_new_block()
         f.on_new_line()
         assert f.get_is_indented_and_update(
             LayoutToken('x', coordinates=LayoutPageCoordinates(x=10, y=10, width=10, height=10))
-        ) is False
+        ) is False  # line 1: first-ever skip
+        f.on_new_line()
+        assert f.get_is_indented_and_update(
+            LayoutToken('x', coordinates=LayoutPageCoordinates(x=10, y=10, width=10, height=10))
+        ) is False  # line 2: stores lineStartX=10, no comparison
         # New block indented right of x=10
         f.on_new_block()
         f.on_new_line()
         assert f.get_is_indented_and_update(
             LayoutToken('x', coordinates=LayoutPageCoordinates(x=50, y=10, width=10, height=10))
-        ) is True
+        ) is True   # line 3 (new block): compare x=50 vs x=10 → LINEINDENT
 
 
 class TestLineIndentationStatusFeatureWithPersistAcrossBlocks:

--- a/tests/models/reference_segmenter/data_test.py
+++ b/tests/models/reference_segmenter/data_test.py
@@ -198,11 +198,11 @@ class TestAlignment:
         items = list(gen.iter_model_data_for_layout_document(doc))
         idx = gen.feature_names.index('alignment')
         alignments = [item.data_line.split()[idx] for item in items]
-        # token '1': ALIGNEDLEFT (first line, no previous)
+        # token '1': ALIGNEDLEFT (first-ever LINESTART, double-skip: lineStartX not set)
         assert alignments[0] == 'ALIGNEDLEFT'
-        # token 'Author': LINEINDENT (indented relative to '1')
-        assert alignments[1] == 'LINEINDENT'
-        # token '2': ALIGNEDLEFT (x=10 < x=50 of previous 'Author' line → not indented)
+        # token 'Author': ALIGNEDLEFT (second LINESTART: previous=None, no comparison)
+        assert alignments[1] == 'ALIGNEDLEFT'
+        # token '2': ALIGNEDLEFT (x=10 < x=50 of 'Author' → not indented)
         assert alignments[2] == 'ALIGNEDLEFT'
 
 


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/88

alignment: GROBID's ReferenceSegmenterParser skips the lineStartX update for the first-ever token (previousFeatures=null) AND skips comparison for the second (previousLineStartX=NaN). The compare_across_blocks=True mode only skipped the first. Add _first_linestart_skipped flag so both skips are honoured.

is_common_name: GROBID's Lexicon stores wordforms from english.wf as-is but test_common() lowercases the query, making capitalised entries (British, October, I, Europe) effectively unreachable. load_lookup_from_wf_file now only stores already-lowercase wordforms to replicate this behaviour.

Result: 3-9_v1 goes from 136 alignment diffs + 4 is_common_name diffs (2 label changes) to 0 non-label feature differences.