### PR TITLE
Emit I-<other> when translating O labels that follow annotated spans in DeLFT training data

### DIFF
--- a/sciencebeam_parser/training/cli/generate_delft_data.py
+++ b/sciencebeam_parser/training/cli/generate_delft_data.py
@@ -73,12 +73,23 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def translate_tags_IOB_to_grobid(tag: str) -> str:
+_GROBID_OTHER_LABELS = frozenset({'<other>', 'I-<other>'})
+
+
+def translate_tags_IOB_to_grobid(
+    tag: str,
+    prev_grobid_tag: Optional[str] = None
+) -> str:
     """
-    Convert labels from IOB2 to the ones used by GROBID (expected by the wapiti model)
+    Convert labels from IOB2 to the ones used by GROBID (expected by the wapiti model).
+
+    When prev_grobid_tag is supplied the function also replicates GROBID's convention of
+    emitting I-<other> for the first "other" token immediately after an annotated span.
     """
     if tag == 'O':
-        # outside
+        # GROBID uses I-<other> for the first "other" token after any annotated span
+        if prev_grobid_tag is not None and prev_grobid_tag not in _GROBID_OTHER_LABELS:
+            return 'I-<other>'
         return '<other>'
     if tag.startswith('B-'):
         # begin
@@ -89,14 +100,23 @@ def translate_tags_IOB_to_grobid(tag: str) -> str:
     return tag
 
 
+def _translate_doc_tags_IOB_to_grobid(
+    doc_tag_result: Sequence[Tuple[str, str]]
+) -> List[Tuple[str, str]]:
+    translated: List[Tuple[str, str]] = []
+    prev_grobid_tag: Optional[str] = None
+    for token_text, tag in doc_tag_result:
+        grobid_tag = translate_tags_IOB_to_grobid(tag, prev_grobid_tag)
+        translated.append((token_text, grobid_tag))
+        prev_grobid_tag = grobid_tag
+    return translated
+
+
 def translate_tag_result_tags_IOB_to_grobid(
     tag_result: Sequence[Sequence[Tuple[str, str]]]
 ) -> List[List[Tuple[str, str]]]:
     return [
-        [
-            (token_text, translate_tags_IOB_to_grobid(tag))
-            for token_text, tag in doc_tag_result
-        ]
+        _translate_doc_tags_IOB_to_grobid(doc_tag_result)
         for doc_tag_result in tag_result
     ]
 

--- a/tests/models/training_data_test.py
+++ b/tests/models/training_data_test.py
@@ -143,3 +143,24 @@ class TestTrainingTeiParser:
             labeled_layout_tokens[0].layout_token.line_meta
             != labeled_layout_tokens[1].layout_token.line_meta
         )
+
+    def test_unannotated_tokens_after_annotated_span_use_O(self):
+        # training_data.py emits plain 'O' for all unannotated tokens regardless of
+        # position. The I-<other> GROBID convention is applied later by
+        # translate_tag_result_tags_IOB_to_grobid in generate_delft_data.py.
+        tei_root = _get_training_tei_with_text([
+            E('head', TOKEN_1, E('lb')),
+            '\n',
+            TOKEN_2, E('lb'),
+            '\n',
+            TOKEN_3, E('lb'),
+            '\n',
+        ])
+        tag_result = SampleTrainingTeiParser().parse_training_tei_to_tag_result(
+            tei_root
+        )
+        assert tag_result == [[
+            (TOKEN_1, 'B-<head>'),
+            (TOKEN_2, 'O'),
+            (TOKEN_3, 'O'),
+        ]]

--- a/tests/training/cli/generate_delft_data_test.py
+++ b/tests/training/cli/generate_delft_data_test.py
@@ -27,7 +27,9 @@ from sciencebeam_parser.models.data import DocumentFeaturesContext, ModelDataGen
 
 import sciencebeam_parser.training.cli.generate_delft_data as generate_delft_data_module
 from sciencebeam_parser.training.cli.generate_delft_data import (
-    main
+    main,
+    translate_tag_result_tags_IOB_to_grobid,
+    translate_tags_IOB_to_grobid
 )
 from sciencebeam_parser.utils.xml_writer import XmlTreeWriter
 from tests.processors.fulltext.model_mocks import MockFullTextModels
@@ -188,6 +190,44 @@ def _test_generate_delft_with_two_tokens_tei_only(
         expected_labels=expected_labels,
         data_generator=data_generator
     )
+
+
+class TestTranslateTagsIOBToGrobid:
+    def test_outside_tag_becomes_other(self):
+        assert translate_tags_IOB_to_grobid('O') == '<other>'
+
+    def test_begin_tag_becomes_i_prefixed(self):
+        assert translate_tags_IOB_to_grobid('B-<title>') == 'I-<title>'
+
+    def test_inside_tag_drops_prefix(self):
+        assert translate_tags_IOB_to_grobid('I-<title>') == '<title>'
+
+    def test_outside_after_annotated_becomes_i_other(self):
+        # GROBID uses I-<other> for the first "other" token immediately after any
+        # annotated span. prev_grobid_tag carries the previous translated label.
+        assert translate_tags_IOB_to_grobid('O', prev_grobid_tag='I-<title>') == 'I-<other>'
+        assert translate_tags_IOB_to_grobid('O', prev_grobid_tag='<title>') == 'I-<other>'
+
+    def test_outside_after_other_stays_other(self):
+        assert translate_tags_IOB_to_grobid('O', prev_grobid_tag='<other>') == '<other>'
+        assert translate_tags_IOB_to_grobid('O', prev_grobid_tag='I-<other>') == '<other>'
+
+    def test_outside_at_document_start_stays_other(self):
+        assert translate_tags_IOB_to_grobid('O', prev_grobid_tag=None) == '<other>'
+
+    def test_translate_doc_applies_i_other_convention(self):
+        # Full document translation: O after B-<title> → I-<other>; subsequent O → <other>
+        tag_result = [[
+            ('token1', 'B-<title>'),
+            ('token2', 'O'),
+            ('token3', 'O'),
+        ]]
+        translated = translate_tag_result_tags_IOB_to_grobid(tag_result)
+        assert translated == [[
+            ('token1', 'I-<title>'),
+            ('token2', 'I-<other>'),
+            ('token3', '<other>'),
+        ]]
 
 
 @log_on_exception


### PR DESCRIPTION
GROBID's TEI SAX parsers (e.g. TEIHeaderSaxParser.writeData()) prefix the first token of every text segment with I-, so the first "other" token after any annotated span becomes I-<other> in Wapiti training data. The Wapiti CRF model learns to predict I-<other> at these positions.

Replicate this convention in sbeam's DeLFT training data generation: translate_tags_IOB_to_grobid now accepts an optional prev_grobid_tag and emits I-<other> instead of <other> when O follows a non-other annotated label. The document-level _translate_doc_tags_IOB_to_grobid threads the previous translated label through the sequence so translate_tag_result_tags_IOB_to_grobid applies the convention correctly.

training_data.py is unchanged — all unannotated tokens continue to emit O. The I-<other> conversion is isolated to the GROBID-specific data generation step.