### PR TITLE
Implement is_location_name for header model via FastMatcher-compatible phrase lookup

### DIFF
--- a/sciencebeam_parser/app/parser.py
+++ b/sciencebeam_parser/app/parser.py
@@ -18,6 +18,7 @@ from sciencebeam_parser.external.pdfalto.wrapper import PdfAltoWrapper, get_defa
 from sciencebeam_parser.external.pdfalto.parser import parse_alto_root
 from sciencebeam_parser.external.wapiti.wrapper import LazyWapitiBinaryWrapper
 from sciencebeam_parser.lookup.loader import load_lookup_from_config
+from sciencebeam_parser.lookup.phrase_match import load_phrase_match_from_path
 from sciencebeam_parser.models.data import AppFeaturesContext
 from sciencebeam_parser.document.layout_document import LayoutDocument
 from sciencebeam_parser.document.semantic_document import (
@@ -84,6 +85,12 @@ def load_app_features_context(
     config: AppConfig,
     download_manager: DownloadManager
 ):
+    location_name_config = config.get('lookup', {}).get('location_name')
+    location_name_path: Optional[str] = None
+    if location_name_config:
+        paths = location_name_config.get('paths', [])
+        if paths:
+            location_name_path = download_manager.download_if_url(paths[0])
     return AppFeaturesContext(
         country_lookup=load_lookup_from_config(
             config.get('lookup', {}).get('country'),
@@ -100,7 +107,8 @@ def load_app_features_context(
         common_name_lookup=load_lookup_from_config(
             config.get('lookup', {}).get('common_name'),
             download_manager=download_manager
-        )
+        ),
+        location_name_phrase_match=load_phrase_match_from_path(location_name_path)
     )
 
 

--- a/sciencebeam_parser/lookup/phrase_match.py
+++ b/sciencebeam_parser/lookup/phrase_match.py
@@ -1,0 +1,146 @@
+import logging
+import re
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+
+LOGGER = logging.getLogger(__name__)
+
+# Single-character tokens matching these are skipped during both phrase loading and matching.
+# Mirrors GROBID's TextUtilities.delimiters / FastMatcher delimiter handling.
+_DELIMITER_CHARS: frozenset = frozenset(
+    '\n\r\t\f '
+    + '‌'          # zero-width non-joiner
+    + ' '          # non-breaking space
+    + '([*,:;?.!/)]\\'
+    + '-−–—‐'  # hyphen / dash variants
+    + '«»'               # angle quotation marks
+    + '„“”'         # double quotation variants
+    + '‘’\''             # single quotation
+    + '`$#@•'                 # misc / bullet
+    + '♦♥♣♠'   # card suits
+    + '。、，・'   # CJK punctuation
+    + '†‡§¶⁋ǂ'  # footnote markers
+)
+
+# Matches a "word" token: one or more characters that are NOT delimiters or whitespace.
+_WORD_RE = re.compile(
+    '[^\\s\\(\\)\\[\\]\\*,:;?\\.!/\\\\\\-'
+    + '−–—‐'
+    + '«»„“”‘’'
+    + '`\'$#@•'
+    + '♦♥♣♠'
+    + '。、，・'
+    + '†‡§¶⁋ǂ'
+    + '‌ '
+    + ']+'
+)
+
+
+def _phrase_to_word_tokens(phrase: str) -> List[str]:
+    """Return the lowercased non-delimiter word tokens of a phrase."""
+    return _WORD_RE.findall(phrase.lower())
+
+
+_MatchState = Tuple[List[Dict], List[int], List[int]]
+
+
+class SequencePhraseMatch:
+    """
+    Case-insensitive multi-token phrase matcher.
+
+    Replicates GROBID's FastMatcher.matchLayoutToken(tokens, ignoreDelimiters=True,
+    caseSensitive=False).  Delimiter single-character tokens are skipped (but still
+    counted in the position index) both during phrase loading and during matching,
+    so that spans are reported as raw token-list indices inclusive of any embedded
+    punctuation (e.g. tokens ["Model", ",", "Colorado"] -> match span {0, 1, 2}).
+    """
+
+    def __init__(self, phrases: Iterable[str]) -> None:
+        self._trie: Dict = {}
+        count = 0
+        for phrase in phrases:
+            self._add_phrase(phrase)
+            count += 1
+        LOGGER.debug('SequencePhraseMatch: loaded %d phrases', count)
+
+    def _add_phrase(self, phrase: str) -> None:
+        tokens = _phrase_to_word_tokens(phrase)
+        if not tokens:
+            return
+        node = self._trie
+        for token in tokens:
+            if token not in node:
+                node[token] = {}
+            node = node[token]
+        node['#'] = {}
+
+    def _advance(
+        self,
+        state: _MatchState,
+        token_lower: str,
+        current_pos: int,
+        results: Set[int]
+    ) -> _MatchState:
+        """
+        Advance all open matches by one non-delimiter token.
+        Completed matches (nodes containing '#') are flushed into *results*.
+        Returns the updated match state.
+        """
+        current_matches, start_positions, last_non_sep_positions = state
+        new_matches: List[Dict] = []
+        new_starts: List[int] = []
+        new_last_non_sep: List[int] = []
+        for i, current_match in enumerate(current_matches):
+            child = current_match.get(token_lower)
+            if child is not None:
+                new_matches.append(child)
+                new_starts.append(start_positions[i])
+                new_last_non_sep.append(current_pos)
+            if '#' in current_match:
+                results.update(range(start_positions[i], last_non_sep_positions[i] + 1))
+        root_child = self._trie.get(token_lower)
+        if root_child is not None:
+            new_matches.append(root_child)
+            new_starts.append(current_pos)
+            new_last_non_sep.append(current_pos)
+        return new_matches, new_starts, new_last_non_sep
+
+    def match_token_indices(self, tokens: List[str]) -> Set[int]:
+        """
+        Return the set of raw token-list indices that fall within at least one matched span.
+
+        Mirrors FastMatcher.matchLayoutToken: delimiter tokens (single-char in
+        _DELIMITER_CHARS) are skipped for matching purposes but their positions
+        are included when they fall inside a matched span.
+        """
+        state: _MatchState = ([], [], [])
+        results: Set[int] = set()
+
+        for current_pos, token_text in enumerate(tokens):
+            if token_text in (' ', '\n'):
+                continue
+            if len(token_text) == 1 and token_text in _DELIMITER_CHARS:
+                continue
+            state = self._advance(state, token_text.lower(), current_pos, results)
+
+        # Flush matches that ended at the last token of the stream
+        current_matches, start_positions, last_non_sep_positions = state
+        for i, current_match in enumerate(current_matches):
+            if '#' in current_match:
+                results.update(range(start_positions[i], last_non_sep_positions[i] + 1))
+
+        return results
+
+
+def load_phrase_match_from_text_file(path: str) -> SequencePhraseMatch:
+    """Load a SequencePhraseMatch from a plain-text file with one phrase per line."""
+    LOGGER.info('loading phrase match from: %r', path)
+    lines = Path(path).read_text(encoding='utf-8').splitlines()
+    return SequencePhraseMatch(line for line in lines if line)
+
+
+def load_phrase_match_from_path(path: Optional[str]) -> Optional[SequencePhraseMatch]:
+    if not path:
+        return None
+    return load_phrase_match_from_text_file(path)

--- a/sciencebeam_parser/models/data.py
+++ b/sciencebeam_parser/models/data.py
@@ -8,6 +8,7 @@ from typing import Callable, Generic, Iterable, List, NamedTuple, Optional, Type
 from lxml import etree
 
 from sciencebeam_parser.lookup import TextLookUp
+from sciencebeam_parser.lookup.phrase_match import SequencePhraseMatch
 from sciencebeam_parser.document.layout_document import LayoutDocument, LayoutToken,  LayoutLine
 from sciencebeam_parser.external.pdfalto.parser import parse_alto_root
 
@@ -29,6 +30,7 @@ class AppFeaturesContext(NamedTuple):
     first_name_lookup: Optional[TextLookUp] = None
     last_name_lookup: Optional[TextLookUp] = None
     common_name_lookup: Optional[TextLookUp] = None
+    location_name_phrase_match: Optional[SequencePhraseMatch] = None
 
 
 DEFAULT_APP_FEATURES_CONTEXT = AppFeaturesContext()
@@ -576,7 +578,8 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
         line_indentation_status_feature: Optional[LineIndentationStatusFeature] = None,
         grobid_nn: int = 0,
         grobid_line_length: int = 0,
-        max_grobid_line_length: int = 0
+        max_grobid_line_length: int = 0,
+        is_location_name: bool = False
     ) -> None:
         super().__init__(layout_token)
         self.layout_line = layout_line
@@ -596,6 +599,7 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
         self.grobid_nn = grobid_nn
         self.grobid_line_length = grobid_line_length
         self.max_grobid_line_length = max_grobid_line_length
+        self.is_location_name = is_location_name
 
     def get_layout_model_data(self, features: List[str]) -> LayoutModelData:
         return LayoutModelData(
@@ -630,6 +634,9 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
 
     def get_dummy_page_status(self) -> str:
         return 'PAGEIN'
+
+    def get_str_is_location_name(self) -> str:
+        return '1' if self.is_location_name else '0'
 
     def get_is_indented_and_update(self) -> bool:
         assert self.line_indentation_status_feature
@@ -874,6 +881,18 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
             1
             for _ in layout_document.iter_all_tokens()
         ))
+        # Pre-compute location name indices if a phrase match is configured.
+        # This mirrors GROBID's HeaderParser which runs tokenPositionsLocationNames()
+        # before the feature loop and marks tokens within matched spans.
+        location_phrase_match = (
+            self.document_features_context.app_features_context.location_name_phrase_match
+        )
+        location_name_indices: frozenset = frozenset()
+        if location_phrase_match is not None:
+            all_token_texts = [t.text for t in layout_document.iter_all_tokens()]
+            location_name_indices = frozenset(
+                location_phrase_match.match_token_indices(all_token_texts)
+            )
         document_token_index = 0
         for block in layout_document.iter_all_blocks():
             line_indentation_status_feature.on_new_block()
@@ -911,7 +930,8 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
                             line_indentation_status_feature=line_indentation_status_feature,
                             grobid_nn=grobid_nn,
                             grobid_line_length=grobid_line_length,
-                            max_grobid_line_length=max_grobid_line_length
+                            max_grobid_line_length=max_grobid_line_length,
+                            is_location_name=(document_token_index in location_name_indices)
                         )
                     )
                     previous_layout_token = token

--- a/sciencebeam_parser/models/header/data.py
+++ b/sciencebeam_parser/models/header/data.py
@@ -48,7 +48,7 @@ class HeaderDataGenerator(ContextAwareLayoutTokenModelDataGenerator):
             FeatureDef('is_year', lambda f: f.get_str_is_year()),
             FeatureDef('is_month', lambda f: f.get_str_is_month()),
             FeatureDef('is_location_name',
-                       lambda f: f.get_dummy_str_is_location_name()),
+                       lambda f: f.get_str_is_location_name()),
             FeatureDef('is_email', lambda f: f.get_dummy_str_is_email()),
             FeatureDef('is_http', lambda f: f.get_str_is_http()),
             FeatureDef('punctuation_type', lambda f: f.get_punctuation_type_feature()),

--- a/sciencebeam_parser/resources/default_config/config.yml
+++ b/sciencebeam_parser/resources/default_config/config.yml
@@ -79,6 +79,9 @@ lookup:
   common_name:
     paths:
       - https://raw.githubusercontent.com/kermitt2/grobid/0.9.0/grobid-home/lexicon/wordforms/english.wf
+  location_name:
+    paths:
+      - https://raw.githubusercontent.com/kermitt2/grobid/0.9.0/grobid-home/lexicon/places/location.txt
 processors:
   fulltext:
     noise_filter_enabled: true

--- a/tests/lookup/phrase_match_test.py
+++ b/tests/lookup/phrase_match_test.py
@@ -1,0 +1,72 @@
+from sciencebeam_parser.lookup.phrase_match import SequencePhraseMatch
+
+
+def _match(phrases, tokens):
+    return SequencePhraseMatch(phrases).match_token_indices(tokens)
+
+
+class TestSequencePhraseMatchSingleWord:
+    def test_single_word_phrase_matches_exact_token(self):
+        assert 0 in _match(['model'], ['model', 'city'])
+
+    def test_single_word_phrase_is_case_insensitive(self):
+        assert 0 in _match(['Model'], ['MODEL', 'city'])
+
+    def test_single_word_phrase_does_not_match_different_token(self):
+        assert _match(['model'], ['city']) == set()
+
+    def test_single_word_at_end_of_stream_is_matched(self):
+        assert 1 in _match(['model'], ['city', 'model'])
+
+    def test_only_matched_token_is_in_result(self):
+        result = _match(['model'], ['city', 'model', 'data'])
+        assert result == {1}
+
+
+class TestSequencePhraseMatchMultiWord:
+    def test_two_word_phrase_matches_consecutive_tokens(self):
+        result = _match(['New York'], ['New', 'York', 'city'])
+        assert result == {0, 1}
+
+    def test_two_word_phrase_is_case_insensitive(self):
+        result = _match(['New York'], ['new', 'york', 'city'])
+        assert result == {0, 1}
+
+    def test_two_word_phrase_does_not_match_partial(self):
+        # Only 'New' present, 'York' missing → no match
+        result = _match(['New York'], ['new', 'city'])
+        assert result == set()
+
+    def test_delimiter_between_phrase_words_is_skipped(self):
+        # GROBID skips delimiter tokens (like ',') when matching
+        result = _match(['Model Colorado'], ['Model', ',', 'Colorado'])
+        # span [0,2] inclusive: comma at position 1 is also marked
+        assert result == {0, 1, 2}
+
+
+class TestSequencePhraseMatchOverlapping:
+    def test_shorter_and_longer_phrase_both_recorded(self):
+        # 'Model' is a standalone entry AND 'Model Town' is a two-word entry.
+        result = _match(['Model', 'Model Town'], ['Model', 'Town', 'data'])
+        # 'Model' alone → [0,0]; 'Model Town' → [0,1]
+        assert 0 in result
+        assert 1 in result
+
+    def test_multiple_independent_matches(self):
+        result = _match(['Method', 'model'], ['Method', 'based', 'on', 'model'])
+        assert result == {0, 3}
+
+
+class TestSequencePhraseMatchDelimiters:
+    def test_delimiter_only_tokens_are_not_matched(self):
+        result = _match([','], [',', '.', ';'])
+        assert result == set()
+
+    def test_delimiter_between_non_matching_words_does_not_create_match(self):
+        result = _match(['foo bar'], ['foo', ',', 'baz'])
+        assert result == set()
+
+    def test_standalone_on_uppercased_entry_matches_lowercase(self):
+        # 'ON' is in location.txt; matching must be case-insensitive
+        result = _match(['ON'], ['based', 'on', 'a'])
+        assert result == {1}


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/88

Replace the dummy is_location_name='0' feature in the header CRF model with a real gazetteer lookup backed by GROBID's location.txt. Introduces SequencePhraseMatch, a Python port of GROBID's FastMatcher.matchLayoutToken (case-insensitive, delimiter-skipping trie), and pre-computes matched token spans per document in the feature generator.

This removes the dominant source of feature divergence between sbeam and GROBID on header documents (e.g. common words such as 'METHOD', 'on', 'model' are single-word entries in location.txt), which in turn eliminates cascading Viterbi divergence that caused spurious I-<other>/<other> label differences and incorrect title extraction on documents like 1-148_v3.