### PR TITLE
Implement is_email for header and segmentation models

### DIFF
--- a/sciencebeam_parser/models/data.py
+++ b/sciencebeam_parser/models/data.py
@@ -18,6 +18,12 @@ LOGGER = logging.getLogger(__name__)
 
 YEAR_PATTERN = re.compile(r'[12]\d{3}')
 
+# Mirrors GROBID's TextUtilities.emailPattern:
+#   \w+((\.|‐|_|,)\w+)?\s?((\.|‐|_|,)\w+)?\s?@\s?\w+(\s?(\.|‐)\s?\w+)+
+_EMAIL_PATTERN = re.compile(
+    r'\w+([.\-_,]\w+)?\s?([.\-_,]\w+)?\s?@\s?\w+(\s?[.\-]\s?\w+)+'
+)
+
 MONTH_NAMES = frozenset({
     'january', 'february', 'march', 'april', 'may', 'june',
     'july', 'august', 'september', 'october', 'november', 'december',
@@ -579,7 +585,8 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
         grobid_nn: int = 0,
         grobid_line_length: int = 0,
         max_grobid_line_length: int = 0,
-        is_location_name: bool = False
+        is_location_name: bool = False,
+        is_email: bool = False
     ) -> None:
         super().__init__(layout_token)
         self.layout_line = layout_line
@@ -600,6 +607,7 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
         self.grobid_line_length = grobid_line_length
         self.max_grobid_line_length = max_grobid_line_length
         self.is_location_name = is_location_name
+        self.is_email = is_email
 
     def get_layout_model_data(self, features: List[str]) -> LayoutModelData:
         return LayoutModelData(
@@ -637,6 +645,9 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
 
     def get_str_is_location_name(self) -> str:
         return '1' if self.is_location_name else '0'
+
+    def get_str_is_email(self) -> str:
+        return '1' if self.is_email else '0'
 
     def get_is_indented_and_update(self) -> bool:
         assert self.line_indentation_status_feature
@@ -893,6 +904,27 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
             location_name_indices = frozenset(
                 location_phrase_match.match_token_indices(all_token_texts)
             )
+        # Pre-compute email token indices. Mirrors GROBID's
+        # Lexicon.tokenPositionsEmailPattern(): run emailPattern against the
+        # reconstructed full text and map character spans back to token indices.
+        all_tokens_for_email = list(layout_document.iter_all_tokens())
+        full_text = ''.join(t.text + t.whitespace for t in all_tokens_for_email)
+        email_token_indices: frozenset = frozenset()
+        if '@' in full_text:
+            char_start_by_token: List[int] = []
+            pos = 0
+            for t in all_tokens_for_email:
+                char_start_by_token.append(pos)
+                pos += len(t.text) + len(t.whitespace)
+            matched: set = set()
+            for m in _EMAIL_PATTERN.finditer(full_text):
+                m_start, m_end = m.start(), m.end()
+                for i, t in enumerate(all_tokens_for_email):
+                    t_start = char_start_by_token[i]
+                    t_end = t_start + len(t.text)
+                    if t_start < m_end and t_end > m_start:
+                        matched.add(i)
+            email_token_indices = frozenset(matched)
         document_token_index = 0
         for block in layout_document.iter_all_blocks():
             line_indentation_status_feature.on_new_block()
@@ -931,7 +963,8 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
                             grobid_nn=grobid_nn,
                             grobid_line_length=grobid_line_length,
                             max_grobid_line_length=max_grobid_line_length,
-                            is_location_name=(document_token_index in location_name_indices)
+                            is_location_name=(document_token_index in location_name_indices),
+                            is_email=(document_token_index in email_token_indices)
                         )
                     )
                     previous_layout_token = token

--- a/sciencebeam_parser/models/data.py
+++ b/sciencebeam_parser/models/data.py
@@ -3,13 +3,13 @@ import math
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Callable, Generic, Iterable, List, NamedTuple, Optional, TypeVar
+from typing import Callable, FrozenSet, Generic, Iterable, List, NamedTuple, Optional, TypeVar
 
 from lxml import etree
 
 from sciencebeam_parser.lookup import TextLookUp
 from sciencebeam_parser.lookup.phrase_match import SequencePhraseMatch
-from sciencebeam_parser.document.layout_document import LayoutDocument, LayoutToken,  LayoutLine
+from sciencebeam_parser.document.layout_document import LayoutDocument, LayoutToken, LayoutLine
 from sciencebeam_parser.external.pdfalto.parser import parse_alto_root
 
 
@@ -23,6 +23,33 @@ YEAR_PATTERN = re.compile(r'[12]\d{3}')
 _EMAIL_PATTERN = re.compile(
     r'\w+([.\-_,]\w+)?\s?([.\-_,]\w+)?\s?@\s?\w+(\s?[.\-]\s?\w+)+'
 )
+
+
+def _get_email_token_indices(tokens: List[LayoutToken]) -> FrozenSet[int]:
+    text_parts: List[str] = []
+    char_start_by_token: List[int] = []
+    pos = 0
+    last = len(tokens) - 1
+    for i, t in enumerate(tokens):
+        char_start_by_token.append(pos)
+        text_parts.append(t.text)
+        pos += len(t.text)
+        if i < last:
+            text_parts.append(t.whitespace)
+            pos += len(t.whitespace)
+    full_text = ''.join(text_parts)
+    if '@' not in full_text:
+        return frozenset()
+    matched: set = set()
+    for m in _EMAIL_PATTERN.finditer(full_text):
+        m_start, m_end = m.start(), m.end()
+        for i, t in enumerate(tokens):
+            t_start = char_start_by_token[i]
+            t_end = t_start + len(t.text)
+            if t_start < m_end and t_end > m_start:
+                matched.add(i)
+    return frozenset(matched)
+
 
 MONTH_NAMES = frozenset({
     'january', 'february', 'march', 'april', 'may', 'june',
@@ -904,27 +931,9 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
             location_name_indices = frozenset(
                 location_phrase_match.match_token_indices(all_token_texts)
             )
-        # Pre-compute email token indices. Mirrors GROBID's
-        # Lexicon.tokenPositionsEmailPattern(): run emailPattern against the
-        # reconstructed full text and map character spans back to token indices.
-        all_tokens_for_email = list(layout_document.iter_all_tokens())
-        full_text = ''.join(t.text + t.whitespace for t in all_tokens_for_email)
-        email_token_indices: frozenset = frozenset()
-        if '@' in full_text:
-            char_start_by_token: List[int] = []
-            pos = 0
-            for t in all_tokens_for_email:
-                char_start_by_token.append(pos)
-                pos += len(t.text) + len(t.whitespace)
-            matched: set = set()
-            for m in _EMAIL_PATTERN.finditer(full_text):
-                m_start, m_end = m.start(), m.end()
-                for i, t in enumerate(all_tokens_for_email):
-                    t_start = char_start_by_token[i]
-                    t_end = t_start + len(t.text)
-                    if t_start < m_end and t_end > m_start:
-                        matched.add(i)
-            email_token_indices = frozenset(matched)
+        email_token_indices = _get_email_token_indices(
+            list(layout_document.iter_all_tokens())
+        )
         document_token_index = 0
         for block in layout_document.iter_all_blocks():
             line_indentation_status_feature.on_new_block()

--- a/sciencebeam_parser/models/header/data.py
+++ b/sciencebeam_parser/models/header/data.py
@@ -49,7 +49,7 @@ class HeaderDataGenerator(ContextAwareLayoutTokenModelDataGenerator):
             FeatureDef('is_month', lambda f: f.get_str_is_month()),
             FeatureDef('is_location_name',
                        lambda f: f.get_str_is_location_name()),
-            FeatureDef('is_email', lambda f: f.get_dummy_str_is_email()),
+            FeatureDef('is_email', lambda f: f.get_str_is_email()),
             FeatureDef('is_http', lambda f: f.get_str_is_http()),
             FeatureDef('punctuation_type', lambda f: f.get_punctuation_type_feature()),
             FeatureDef('is_largest_font', lambda f: f.get_str_is_largest_font_size()),

--- a/sciencebeam_parser/models/segmentation/data.py
+++ b/sciencebeam_parser/models/segmentation/data.py
@@ -443,7 +443,7 @@ class SegmentationDataGenerator(ModelDataGenerator):
             FeatureDef('is_first_name', lambda f: f.get_dummy_str_is_first_name()),
             FeatureDef('is_year', lambda f: f.get_str_is_year()),
             FeatureDef('is_month', lambda f: f.get_str_is_month()),
-            FeatureDef('is_email', lambda f: f.get_dummy_str_is_email()),
+            FeatureDef('is_email', lambda f: f.get_str_is_email()),
             FeatureDef('is_http', lambda f: f.get_str_is_http()),
             FeatureDef('relative_document_position',
                        lambda f: f.get_str_relative_document_position()),

--- a/tests/models/header/data_test.py
+++ b/tests/models/header/data_test.py
@@ -1,0 +1,65 @@
+from sciencebeam_parser.document.layout_document import (
+    LayoutBlock,
+    LayoutDocument,
+    LayoutLine,
+    LayoutToken
+)
+from sciencebeam_parser.models.data import DEFAULT_DOCUMENT_FEATURES_CONTEXT
+from sciencebeam_parser.models.header.data import HeaderDataGenerator
+
+
+def _get_feature(token_text: str, feature_name: str) -> str:
+    tokens = [LayoutToken(token_text)]
+    line = LayoutLine(tokens)
+    doc = LayoutDocument.for_blocks([LayoutBlock(lines=[line])])
+    gen = HeaderDataGenerator(DEFAULT_DOCUMENT_FEATURES_CONTEXT)
+    data_list = list(gen.iter_model_data_for_layout_document(doc))
+    for item in data_list:
+        if item.data_line and item.data_line.split()[0] == token_text:
+            cols = item.data_line.split()
+            idx = gen.feature_names.index(feature_name)
+            return cols[idx]
+    raise KeyError(f'token {token_text!r} not found')
+
+
+def _get_email_feature(token_texts_with_whitespace, target_token_text: str) -> str:
+    tokens = [
+        LayoutToken(text, whitespace=ws)
+        for text, ws in token_texts_with_whitespace
+    ]
+    line = LayoutLine(tokens)
+    doc = LayoutDocument.for_blocks([LayoutBlock(lines=[line])])
+    gen = HeaderDataGenerator(DEFAULT_DOCUMENT_FEATURES_CONTEXT)
+    idx = gen.feature_names.index('is_email')
+    for item in gen.iter_model_data_for_layout_document(doc):
+        if item.data_line and item.data_line.split()[0] == target_token_text:
+            return item.data_line.split()[idx]
+    raise KeyError(f'token {target_token_text!r} not found')
+
+
+class TestIsEmail:
+    def test_at_token_in_full_email_gives_1(self):
+        tokens = [
+            ('andre', ''), ('.', ''), ('freitas', ''),
+            ('@', ''), ('slmandic', ''), ('.', ''), ('edu', ''), ('.', ''), ('br', ' ')
+        ]
+        assert _get_email_feature(tokens, '@') == '1'
+
+    def test_local_part_token_in_full_email_gives_1(self):
+        tokens = [
+            ('andre', ''), ('.', ''), ('freitas', ''),
+            ('@', ''), ('slmandic', ''), ('.', ''), ('edu', ''), ('.', ''), ('br', ' ')
+        ]
+        assert _get_email_feature(tokens, 'andre') == '1'
+
+    def test_domain_token_in_full_email_gives_1(self):
+        tokens = [
+            ('user', ''), ('@', ''), ('example', ''), ('.', ''), ('com', ' ')
+        ]
+        assert _get_email_feature(tokens, 'example') == '1'
+
+    def test_word_without_at_sign_gives_0(self):
+        assert _get_feature('word', 'is_email') == '0'
+
+    def test_at_sign_alone_gives_0(self):
+        assert _get_feature('@', 'is_email') == '0'


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/88

Mirror GROBID's Lexicon.tokenPositionsEmailPattern(): reconstruct full token text, run the email regex once per document, map character spans back to token indices, and pass is_email per-token to ContextAwareLayoutTokenFeatures. Wire the real getter into HeaderDataGenerator and SegmentationDataGenerator (replacing the dummy '0' stubs).

Tests in tests/models/header/data_test.py cover the full email address case (andre.freitas@slmandic.edu.br), single-word and '@' non-matches.