### PR TITLE
Deduplicate repeated authors from correspondence section in header

### DIFF
--- a/sciencebeam_parser/processors/fulltext/config.py
+++ b/sciencebeam_parser/processors/fulltext/config.py
@@ -41,6 +41,8 @@ class FullTextProcessorConfig(NamedTuple):
     extract_figure_fields: bool = True
     extract_table_fields: bool = True
     merge_raw_authors: bool = False
+    deduplicate_raw_authors: bool = True
+    deduplicate_raw_authors_use_initial_fallback: bool = True
     extract_graphic_bounding_boxes: bool = True
     extract_graphic_assets: bool = False
     use_cv_model: bool = False

--- a/sciencebeam_parser/processors/fulltext/processor.py
+++ b/sciencebeam_parser/processors/fulltext/processor.py
@@ -101,6 +101,48 @@ from sciencebeam_parser.processors.fulltext.config import (
 LOGGER = logging.getLogger(__name__)
 
 
+def _is_initial(s: str) -> bool:
+    return len(s.replace('.', '').replace(' ', '')) <= 2
+
+
+def _authors_match(
+    a: SemanticAuthor,
+    b: SemanticAuthor,
+    use_initial_fallback: bool
+) -> bool:
+    if not a.surname_text or a.surname_text.lower() != b.surname_text.lower():
+        return False
+    gn_a = a.given_name_text
+    gn_b = b.given_name_text
+    if not gn_a or not gn_b:
+        return False
+    if not _is_initial(gn_a) and not _is_initial(gn_b):
+        return gn_a.lower() == gn_b.lower()
+    if not use_initial_fallback:
+        return False
+    return gn_a[0].lower() == gn_b[0].lower()
+
+
+def _iter_deduplicated_authors(
+    raw_authors: List[SemanticRawAuthors],
+    parsed_per_block: List[List[SemanticContentWrapper]],
+    use_initial_fallback: bool
+) -> Iterable[SemanticContentWrapper]:
+    seen: List[SemanticAuthor] = []
+    for raw_author, parsed in zip(raw_authors, parsed_per_block):
+        parsed_authors = [c for c in parsed if isinstance(c, SemanticAuthor)]
+        if seen and parsed_authors and all(
+            any(_authors_match(a, s, use_initial_fallback) for s in seen)
+            for a in parsed_authors
+        ):
+            yield SemanticNote(layout_block=raw_author.merged_block, note_type='raw_authors')
+        else:
+            for item in parsed:
+                yield item
+                if isinstance(item, SemanticAuthor):
+                    seen.append(item)
+
+
 class FullTextProcessorDocumentContext(NamedTuple):
     pdf_path: Optional[str] = None
     temp_dir: Optional[str] = None
@@ -497,17 +539,19 @@ class FullTextProcessor:
                 app_features_context=self.app_features_context
             )
             LOGGER.debug('labeled_layout_tokens_list (author): %r', labeled_layout_tokens_list)
-            authors_iterable = (
-                author
-                for labeled_layout_tokens in labeled_layout_tokens_list
-                for author in (
-                    self.name_header_model.iter_semantic_content_for_labeled_layout_tokens(
-                        labeled_layout_tokens
-                    )
-                )
-            )
-            for author in authors_iterable:
-                result_content.append(author)
+            parsed_per_block = [
+                list(self.name_header_model.iter_semantic_content_for_labeled_layout_tokens(llt))
+                for llt in labeled_layout_tokens_list
+            ]
+            if self.config.deduplicate_raw_authors and not self.config.merge_raw_authors:
+                result_content.extend(_iter_deduplicated_authors(
+                    raw_authors,
+                    parsed_per_block,
+                    self.config.deduplicate_raw_authors_use_initial_fallback
+                ))
+            else:
+                for parsed in parsed_per_block:
+                    result_content.extend(parsed)
         semantic_parent.mixed_content = result_content
 
     def _process_raw_affiliations(self, semantic_document: SemanticDocument):

--- a/sciencebeam_parser/processors/fulltext/processor.py
+++ b/sciencebeam_parser/processors/fulltext/processor.py
@@ -126,23 +126,20 @@ def _authors_match(
 
 
 def _iter_deduplicated_authors(
-    raw_authors: List[SemanticRawAuthors],
     parsed_per_block: List[List[SemanticContentWrapper]],
     use_initial_fallback: bool
 ) -> Iterable[SemanticContentWrapper]:
     seen: List[SemanticAuthor] = []
-    for raw_author, parsed in zip(raw_authors, parsed_per_block):
-        parsed_authors = [c for c in parsed if isinstance(c, SemanticAuthor)]
-        if seen and parsed_authors and all(
-            any(_authors_match(a, s, use_initial_fallback) for s in seen)
-            for a in parsed_authors
-        ):
-            yield SemanticNote(layout_block=raw_author.merged_block, note_type='raw_authors')
-        else:
-            for item in parsed:
-                yield item
-                if isinstance(item, SemanticAuthor):
+    for parsed in parsed_per_block:
+        for item in parsed:
+            if isinstance(item, SemanticAuthor):
+                if seen and any(_authors_match(item, s, use_initial_fallback) for s in seen):
+                    yield SemanticNote(layout_block=item.merged_block, note_type='raw_authors')
+                else:
+                    yield item
                     seen.append(item)
+            else:
+                yield item
 
 
 class FullTextProcessorDocumentContext(NamedTuple):
@@ -547,7 +544,6 @@ class FullTextProcessor:
             ]
             if self.config.deduplicate_raw_authors and not self.config.merge_raw_authors:
                 result_content.extend(_iter_deduplicated_authors(
-                    raw_authors,
                     parsed_per_block,
                     self.config.deduplicate_raw_authors_use_initial_fallback
                 ))

--- a/sciencebeam_parser/processors/fulltext/processor.py
+++ b/sciencebeam_parser/processors/fulltext/processor.py
@@ -114,6 +114,8 @@ def _authors_match(
         return False
     gn_a = a.given_name_text
     gn_b = b.given_name_text
+    if not gn_a and not gn_b:
+        return True  # both surname-only → same person
     if not gn_a or not gn_b:
         return False
     if not _is_initial(gn_a) and not _is_initial(gn_b):

--- a/tests/processors/fulltext/processor_test.py
+++ b/tests/processors/fulltext/processor_test.py
@@ -383,6 +383,47 @@ class TestFullTextProcessor:
         notes = list(semantic_document.front.iter_by_type(SemanticNote))
         assert len(notes) == 0
 
+    def test_should_deduplicate_only_duplicate_authors_in_mixed_block(
+        self, fulltext_models_mock: MockFullTextModels
+    ):
+        # Block 1: Alice Smith
+        given1 = LayoutBlock.for_text('Alice')
+        sur1 = LayoutBlock.for_text('Smith')
+        authors_block = LayoutBlock.merge_blocks([given1, sur1])
+        # Block 2: Alice Smith (duplicate) + Bob Jones (new)
+        given2a = LayoutBlock.for_text('Alice')
+        sur2a = LayoutBlock.for_text('Smith')
+        given2b = LayoutBlock.for_text('Bob')
+        sur2b = LayoutBlock.for_text('Jones')
+        corresp_block = LayoutBlock.merge_blocks([given2a, sur2a, given2b, sur2b])
+
+        fulltext_models_mock.segmentation_model_mock.update_label_by_layout_block(
+            LayoutBlock.merge_blocks([authors_block, corresp_block]), '<header>'
+        )
+        fulltext_models_mock.header_model_mock.update_label_by_layout_block(
+            authors_block, '<author>'
+        )
+        fulltext_models_mock.header_model_mock.update_label_by_layout_block(
+            corresp_block, '<author>'
+        )
+        self._setup_author_blocks(fulltext_models_mock, given1, sur1)
+        self._setup_author_blocks(fulltext_models_mock, given2a, sur2a)
+        self._setup_author_blocks(fulltext_models_mock, given2b, sur2b)
+
+        layout_document = LayoutDocument(pages=[LayoutPage(blocks=[
+            LayoutBlock.merge_blocks([authors_block, corresp_block])
+        ])])
+        semantic_document = FullTextProcessor(
+            fulltext_models_mock
+        ).get_semantic_document_for_layout_document(layout_document=layout_document)
+        authors = semantic_document.front.authors
+        assert len(authors) == 2
+        assert authors[0].given_name_text == 'Alice'
+        assert authors[1].given_name_text == 'Bob'
+        notes = list(semantic_document.front.iter_by_type(SemanticNote))
+        assert len(notes) == 1
+        assert notes[0].note_type == 'raw_authors'
+
     def test_should_not_deduplicate_when_disabled(
         self, fulltext_models_mock: MockFullTextModels
     ):

--- a/tests/processors/fulltext/processor_test.py
+++ b/tests/processors/fulltext/processor_test.py
@@ -472,7 +472,12 @@ class TestAuthorsMatch:
         b = self._make_author('Richard', 'Coward')
         assert _authors_match(a, b, use_initial_fallback=True) is True
 
-    def test_missing_given_name_no_match(self):
+    def test_both_surname_only_match(self):
+        a = self._make_author('', 'Basit')
+        b = self._make_author('', 'Basit')
+        assert _authors_match(a, b, use_initial_fallback=True) is True
+
+    def test_one_surname_only_no_match(self):
         a = self._make_author('', 'Coward')
         b = self._make_author('Richard', 'Coward')
         assert _authors_match(a, b, use_initial_fallback=True) is False

--- a/tests/processors/fulltext/processor_test.py
+++ b/tests/processors/fulltext/processor_test.py
@@ -24,21 +24,28 @@ from sciencebeam_parser.document.semantic_document import (
     SemanticEditor,
     SemanticFigure,
     SemanticFigureCitation,
+    SemanticGivenName,
     SemanticGraphic,
     SemanticInstitution,
     SemanticInvalidReference,
     SemanticLabel,
     SemanticMarker,
+    SemanticNote,
     SemanticRawReference,
     SemanticRawReferenceText,
     SemanticReference,
     SemanticReferenceCitation,
     SemanticReferenceList,
     SemanticSectionTypes,
+    SemanticSurname,
     SemanticTable,
     SemanticTableCitation,
     SemanticTitle,
     iter_by_semantic_type_recursively
+)
+from sciencebeam_parser.processors.fulltext.processor import (
+    _authors_match,
+    _is_initial
 )
 from sciencebeam_parser.processors.fulltext import processor as processor_module
 from sciencebeam_parser.processors.fulltext.processor import (
@@ -292,6 +299,191 @@ class TestFullTextProcessor:
         assert authors[0].given_name_text == given_name_block.text
         assert authors[0].surname_text == surname_block.text
 
+    def _setup_author_blocks(
+        self,
+        fulltext_models_mock: MockFullTextModels,
+        given_name_block: LayoutBlock,
+        surname_block: LayoutBlock
+    ):
+        fulltext_models_mock.name_header_model_mock.update_label_by_layout_block(
+            given_name_block, '<forename>'
+        )
+        fulltext_models_mock.name_header_model_mock.update_label_by_layout_block(
+            surname_block, '<surname>'
+        )
+
+    def test_should_deduplicate_exact_author_from_second_raw_authors_span(
+        self, fulltext_models_mock: MockFullTextModels
+    ):
+        # Main author list: "Richard Coward"
+        given1 = LayoutBlock.for_text('Richard')
+        sur1 = LayoutBlock.for_text('Coward')
+        authors_block = LayoutBlock.merge_blocks([given1, sur1])
+        # Correspondence section: same "Richard Coward" (separate tokens)
+        given2 = LayoutBlock.for_text('Richard')
+        sur2 = LayoutBlock.for_text('Coward')
+        corresp_block = LayoutBlock.merge_blocks([given2, sur2])
+
+        fulltext_models_mock.segmentation_model_mock.update_label_by_layout_block(
+            LayoutBlock.merge_blocks([authors_block, corresp_block]), '<header>'
+        )
+        fulltext_models_mock.header_model_mock.update_label_by_layout_block(
+            authors_block, '<author>'
+        )
+        fulltext_models_mock.header_model_mock.update_label_by_layout_block(
+            corresp_block, '<author>'
+        )
+        self._setup_author_blocks(fulltext_models_mock, given1, sur1)
+        self._setup_author_blocks(fulltext_models_mock, given2, sur2)
+
+        layout_document = LayoutDocument(pages=[LayoutPage(blocks=[
+            LayoutBlock.merge_blocks([authors_block, corresp_block])
+        ])])
+        semantic_document = FullTextProcessor(
+            fulltext_models_mock
+        ).get_semantic_document_for_layout_document(layout_document=layout_document)
+        authors = semantic_document.front.authors
+        assert len(authors) == 1
+        assert authors[0].given_name_text == 'Richard'
+        assert authors[0].surname_text == 'Coward'
+        notes = list(semantic_document.front.iter_by_type(SemanticNote))
+        assert len(notes) == 1
+        assert notes[0].note_type == 'raw_authors'
+
+    def test_should_keep_second_span_when_not_a_duplicate(
+        self, fulltext_models_mock: MockFullTextModels
+    ):
+        given1 = LayoutBlock.for_text('Alice')
+        sur1 = LayoutBlock.for_text('Smith')
+        authors_block = LayoutBlock.merge_blocks([given1, sur1])
+        given2 = LayoutBlock.for_text('Bob')
+        sur2 = LayoutBlock.for_text('Jones')
+        corresp_block = LayoutBlock.merge_blocks([given2, sur2])
+
+        fulltext_models_mock.segmentation_model_mock.update_label_by_layout_block(
+            LayoutBlock.merge_blocks([authors_block, corresp_block]), '<header>'
+        )
+        fulltext_models_mock.header_model_mock.update_label_by_layout_block(
+            authors_block, '<author>'
+        )
+        fulltext_models_mock.header_model_mock.update_label_by_layout_block(
+            corresp_block, '<author>'
+        )
+        self._setup_author_blocks(fulltext_models_mock, given1, sur1)
+        self._setup_author_blocks(fulltext_models_mock, given2, sur2)
+
+        layout_document = LayoutDocument(pages=[LayoutPage(blocks=[
+            LayoutBlock.merge_blocks([authors_block, corresp_block])
+        ])])
+        semantic_document = FullTextProcessor(
+            fulltext_models_mock
+        ).get_semantic_document_for_layout_document(layout_document=layout_document)
+        authors = semantic_document.front.authors
+        assert len(authors) == 2
+        notes = list(semantic_document.front.iter_by_type(SemanticNote))
+        assert len(notes) == 0
+
+    def test_should_not_deduplicate_when_disabled(
+        self, fulltext_models_mock: MockFullTextModels
+    ):
+        given1 = LayoutBlock.for_text('Richard')
+        sur1 = LayoutBlock.for_text('Coward')
+        authors_block = LayoutBlock.merge_blocks([given1, sur1])
+        given2 = LayoutBlock.for_text('Richard')
+        sur2 = LayoutBlock.for_text('Coward')
+        corresp_block = LayoutBlock.merge_blocks([given2, sur2])
+
+        fulltext_models_mock.segmentation_model_mock.update_label_by_layout_block(
+            LayoutBlock.merge_blocks([authors_block, corresp_block]), '<header>'
+        )
+        fulltext_models_mock.header_model_mock.update_label_by_layout_block(
+            authors_block, '<author>'
+        )
+        fulltext_models_mock.header_model_mock.update_label_by_layout_block(
+            corresp_block, '<author>'
+        )
+        self._setup_author_blocks(fulltext_models_mock, given1, sur1)
+        self._setup_author_blocks(fulltext_models_mock, given2, sur2)
+
+        layout_document = LayoutDocument(pages=[LayoutPage(blocks=[
+            LayoutBlock.merge_blocks([authors_block, corresp_block])
+        ])])
+        semantic_document = FullTextProcessor(
+            fulltext_models_mock,
+            config=FullTextProcessorConfig(deduplicate_raw_authors=False)
+        ).get_semantic_document_for_layout_document(layout_document=layout_document)
+        authors = semantic_document.front.authors
+        assert len(authors) == 2
+
+
+class TestIsInitial:
+    def test_single_letter(self):
+        assert _is_initial('R') is True
+
+    def test_single_letter_with_dot(self):
+        assert _is_initial('R.') is True
+
+    def test_two_letters(self):
+        assert _is_initial('JM') is True
+
+    def test_full_name(self):
+        assert _is_initial('Richard') is False
+
+    def test_short_name_three_chars(self):
+        assert _is_initial('Jan') is False
+
+
+class TestAuthorsMatch:
+    def _make_author(self, given_name: str, surname: str) -> SemanticAuthor:
+        a = SemanticAuthor()
+        if given_name:
+            a.add_content(SemanticGivenName(layout_block=LayoutBlock.for_text(given_name)))
+        if surname:
+            a.add_content(SemanticSurname(layout_block=LayoutBlock.for_text(surname)))
+        return a
+
+    def test_exact_full_name_match(self):
+        a = self._make_author('Richard', 'Coward')
+        b = self._make_author('Richard', 'Coward')
+        assert _authors_match(a, b, use_initial_fallback=True) is True
+
+    def test_different_surnames_no_match(self):
+        a = self._make_author('Richard', 'Coward')
+        b = self._make_author('Richard', 'Smith')
+        assert _authors_match(a, b, use_initial_fallback=True) is False
+
+    def test_different_full_first_names_no_match(self):
+        a = self._make_author('James', 'Smith')
+        b = self._make_author('John', 'Smith')
+        assert _authors_match(a, b, use_initial_fallback=True) is False
+
+    def test_initial_vs_full_name_with_fallback(self):
+        a = self._make_author('R', 'Coward')
+        b = self._make_author('Richard', 'Coward')
+        assert _authors_match(a, b, use_initial_fallback=True) is True
+
+    def test_initial_vs_full_name_without_fallback(self):
+        a = self._make_author('R', 'Coward')
+        b = self._make_author('Richard', 'Coward')
+        assert _authors_match(a, b, use_initial_fallback=False) is False
+
+    def test_case_insensitive(self):
+        a = self._make_author('richard', 'coward')
+        b = self._make_author('Richard', 'Coward')
+        assert _authors_match(a, b, use_initial_fallback=True) is True
+
+    def test_missing_given_name_no_match(self):
+        a = self._make_author('', 'Coward')
+        b = self._make_author('Richard', 'Coward')
+        assert _authors_match(a, b, use_initial_fallback=True) is False
+
+    def test_missing_surname_no_match(self):
+        a = self._make_author('Richard', '')
+        b = self._make_author('Richard', 'Coward')
+        assert _authors_match(a, b, use_initial_fallback=True) is False
+
+
+class TestFullTextProcessorAffiliation:
     def test_should_extract_affiliation_address_from_document(
         self, fulltext_models_mock: MockFullTextModels
     ):


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/88

When the header CRF labels a correspondence line ("Corresponding author: Professor Richard Coward") as <author>, a second SemanticRawAuthors block is produced. Without deduplication this creates phantom author entries — "Richard Coward" alongside the already-extracted "Richard JM Coward".

Introduces _iter_deduplicated_authors: per-block deduplication after name model parsing. Blocks whose authors all match already-seen authors (by surname + full given name, with optional initial fallback) are replaced with SemanticNote(note_type='raw_authors'), preserving the text in the TEI without creating a duplicate author entry.

Two new FullTextProcessorConfig flags:
- deduplicate_raw_authors (default True)
- deduplicate_raw_authors_use_initial_fallback (default True)