### PR TITLE
Fix is_http to use span-based URL detection for header and citation models

### DIFF
--- a/sciencebeam_parser/models/data.py
+++ b/sciencebeam_parser/models/data.py
@@ -24,6 +24,14 @@ _EMAIL_PATTERN = re.compile(
     r'\w+([.\-_,]\w+)?\s?([.\-_,]\w+)?\s?@\s?\w+(\s?[.\-]\s?\w+)+'
 )
 
+# Mirrors GROBID's TextUtilities.urlPattern1 used by HeaderParser and CitationParser.
+# Both parsers use span-based detection: every token within a matched URL span is marked.
+_HTTP_URL_PATTERN = re.compile(
+    r'(?i)(https?|ftp)\s{0,2}:\s{0,2}//\s{0,2}[-A-Z0-9+&@#/%?=~_()|!:.;]*'
+    r'[-A-Z0-9+&@#/%=~_()]'
+    r'|www\s{0,2}\.\s{0,2}[-A-Z0-9+&@#/%?=~_()|!:.;]*[-A-Z0-9+&@#/%=~_()]'
+)
+
 
 def _get_email_token_indices(tokens: List[LayoutToken]) -> FrozenSet[int]:
     text_parts: List[str] = []
@@ -42,6 +50,32 @@ def _get_email_token_indices(tokens: List[LayoutToken]) -> FrozenSet[int]:
         return frozenset()
     matched: set = set()
     for m in _EMAIL_PATTERN.finditer(full_text):
+        m_start, m_end = m.start(), m.end()
+        for i, t in enumerate(tokens):
+            t_start = char_start_by_token[i]
+            t_end = t_start + len(t.text)
+            if t_start < m_end and t_end > m_start:
+                matched.add(i)
+    return frozenset(matched)
+
+
+def _get_http_token_indices(tokens: List[LayoutToken]) -> FrozenSet[int]:
+    text_parts: List[str] = []
+    char_start_by_token: List[int] = []
+    pos = 0
+    last = len(tokens) - 1
+    for i, t in enumerate(tokens):
+        char_start_by_token.append(pos)
+        text_parts.append(t.text)
+        pos += len(t.text)
+        if i < last:
+            text_parts.append(t.whitespace)
+            pos += len(t.whitespace)
+    full_text = ''.join(text_parts)
+    if 'http' not in full_text.lower() and 'www.' not in full_text.lower():
+        return frozenset()
+    matched: set = set()
+    for m in _HTTP_URL_PATTERN.finditer(full_text):
         m_start, m_end = m.start(), m.end()
         for i, t in enumerate(tokens):
             t_start = char_start_by_token[i]
@@ -613,7 +647,8 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
         grobid_line_length: int = 0,
         max_grobid_line_length: int = 0,
         is_location_name: bool = False,
-        is_email: bool = False
+        is_email: bool = False,
+        is_http: bool = False
     ) -> None:
         super().__init__(layout_token)
         self.layout_line = layout_line
@@ -635,6 +670,7 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
         self.max_grobid_line_length = max_grobid_line_length
         self.is_location_name = is_location_name
         self.is_email = is_email
+        self.is_http = is_http
 
     def get_layout_model_data(self, features: List[str]) -> LayoutModelData:
         return LayoutModelData(
@@ -832,6 +868,9 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
         )
 
     def get_str_is_http(self) -> str:
+        return '1' if self.is_http else '0'
+
+    def get_str_is_http_token_based(self) -> str:
         return get_str_bool_feature_value(
             self.token_text.lower().startswith('http')
         )
@@ -915,10 +954,8 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
             for line in block.lines
         }
         max_grobid_line_length = max(grobid_line_length_by_line_id.values())
-        document_token_count = sum((
-            1
-            for _ in layout_document.iter_all_tokens()
-        ))
+        all_tokens = list(layout_document.iter_all_tokens())
+        document_token_count = len(all_tokens)
         # Pre-compute location name indices if a phrase match is configured.
         # This mirrors GROBID's HeaderParser which runs tokenPositionsLocationNames()
         # before the feature loop and marks tokens within matched spans.
@@ -927,13 +964,13 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
         )
         location_name_indices: frozenset = frozenset()
         if location_phrase_match is not None:
-            all_token_texts = [t.text for t in layout_document.iter_all_tokens()]
             location_name_indices = frozenset(
-                location_phrase_match.match_token_indices(all_token_texts)
+                location_phrase_match.match_token_indices(
+                    [t.text for t in all_tokens]
+                )
             )
-        email_token_indices = _get_email_token_indices(
-            list(layout_document.iter_all_tokens())
-        )
+        email_token_indices = _get_email_token_indices(all_tokens)
+        http_token_indices = _get_http_token_indices(all_tokens)
         document_token_index = 0
         for block in layout_document.iter_all_blocks():
             line_indentation_status_feature.on_new_block()
@@ -973,7 +1010,8 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
                             grobid_line_length=grobid_line_length,
                             max_grobid_line_length=max_grobid_line_length,
                             is_location_name=(document_token_index in location_name_indices),
-                            is_email=(document_token_index in email_token_indices)
+                            is_email=(document_token_index in email_token_indices),
+                            is_http=(document_token_index in http_token_indices)
                         )
                     )
                     previous_layout_token = token

--- a/sciencebeam_parser/models/data.py
+++ b/sciencebeam_parser/models/data.py
@@ -18,22 +18,21 @@ LOGGER = logging.getLogger(__name__)
 
 YEAR_PATTERN = re.compile(r'[12]\d{3}')
 
-# Mirrors GROBID's TextUtilities.emailPattern:
-#   \w+((\.|‐|_|,)\w+)?\s?((\.|‐|_|,)\w+)?\s?@\s?\w+(\s?(\.|‐)\s?\w+)+
+# Mirrors GROBID's TextUtilities.emailPattern
 _EMAIL_PATTERN = re.compile(
     r'\w+([.\-_,]\w+)?\s?([.\-_,]\w+)?\s?@\s?\w+(\s?[.\-]\s?\w+)+'
 )
 
-# Mirrors GROBID's TextUtilities.urlPattern1 used by HeaderParser and CitationParser.
-# Both parsers use span-based detection: every token within a matched URL span is marked.
+# Mirrors GROBID's TextUtilities.urlPattern1; header and citation parsers use span-based detection.
 _HTTP_URL_PATTERN = re.compile(
-    r'(?i)(https?|ftp)\s{0,2}:\s{0,2}//\s{0,2}[-A-Z0-9+&@#/%?=~_()|!:.;]*'
-    r'[-A-Z0-9+&@#/%=~_()]'
+    r'(?i)(https?|ftp)\s{0,2}:\s{0,2}//\s{0,2}[-A-Z0-9+&@#/%?=~_()|!:.;]*[-A-Z0-9+&@#/%=~_()]'
     r'|www\s{0,2}\.\s{0,2}[-A-Z0-9+&@#/%?=~_()|!:.;]*[-A-Z0-9+&@#/%=~_()]'
 )
 
 
-def _get_email_token_indices(tokens: List[LayoutToken]) -> FrozenSet[int]:
+def _get_pattern_token_indices(
+    tokens: List[LayoutToken], pattern: re.Pattern, required_substring: str = ''
+) -> FrozenSet[int]:
     text_parts: List[str] = []
     char_start_by_token: List[int] = []
     pos = 0
@@ -46,50 +45,29 @@ def _get_email_token_indices(tokens: List[LayoutToken]) -> FrozenSet[int]:
             text_parts.append(t.whitespace)
             pos += len(t.whitespace)
     full_text = ''.join(text_parts)
-    if '@' not in full_text:
+    if required_substring and required_substring not in full_text:
         return frozenset()
     matched: set = set()
-    for m in _EMAIL_PATTERN.finditer(full_text):
-        m_start, m_end = m.start(), m.end()
+    for m in pattern.finditer(full_text):
         for i, t in enumerate(tokens):
             t_start = char_start_by_token[i]
-            t_end = t_start + len(t.text)
-            if t_start < m_end and t_end > m_start:
+            if t_start < m.end() and t_start + len(t.text) > m.start():
                 matched.add(i)
     return frozenset(matched)
+
+
+def _get_email_token_indices(tokens: List[LayoutToken]) -> FrozenSet[int]:
+    return _get_pattern_token_indices(tokens, _EMAIL_PATTERN, required_substring='@')
 
 
 def _get_http_token_indices(tokens: List[LayoutToken]) -> FrozenSet[int]:
-    text_parts: List[str] = []
-    char_start_by_token: List[int] = []
-    pos = 0
-    last = len(tokens) - 1
-    for i, t in enumerate(tokens):
-        char_start_by_token.append(pos)
-        text_parts.append(t.text)
-        pos += len(t.text)
-        if i < last:
-            text_parts.append(t.whitespace)
-            pos += len(t.whitespace)
-    full_text = ''.join(text_parts)
-    if 'http' not in full_text.lower() and 'www.' not in full_text.lower():
-        return frozenset()
-    matched: set = set()
-    for m in _HTTP_URL_PATTERN.finditer(full_text):
-        m_start, m_end = m.start(), m.end()
-        for i, t in enumerate(tokens):
-            t_start = char_start_by_token[i]
-            t_end = t_start + len(t.text)
-            if t_start < m_end and t_end > m_start:
-                matched.add(i)
-    return frozenset(matched)
+    return _get_pattern_token_indices(tokens, _HTTP_URL_PATTERN)
 
 
 MONTH_NAMES = frozenset({
     'january', 'february', 'march', 'april', 'may', 'june',
     'july', 'august', 'september', 'october', 'november', 'december',
-    'jan', 'feb', 'mar', 'apr', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'
-})
+    'jan', 'feb', 'mar', 'apr', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'})
 
 
 class AppFeaturesContext(NamedTuple):

--- a/sciencebeam_parser/models/reference_segmenter/data.py
+++ b/sciencebeam_parser/models/reference_segmenter/data.py
@@ -39,7 +39,7 @@ class ReferenceSegmenterDataGenerator(ContextAwareLayoutTokenModelDataGenerator)
                        lambda f: f.get_dummy_str_is_location_name()),
             FeatureDef('is_year', lambda f: f.get_str_is_year()),
             FeatureDef('is_month', lambda f: f.get_str_is_month()),
-            FeatureDef('is_http', lambda f: f.get_str_is_http()),
+            FeatureDef('is_http', lambda f: f.get_str_is_http_token_based()),
             FeatureDef('punctuation_profile',
                        lambda f: get_punctuation_type_feature(f.token_text)),
             FeatureDef('line_token_relative_position',

--- a/tests/models/citation/data_test.py
+++ b/tests/models/citation/data_test.py
@@ -8,6 +8,22 @@ from sciencebeam_parser.models.data import DEFAULT_DOCUMENT_FEATURES_CONTEXT
 from sciencebeam_parser.models.citation.data import CitationDataGenerator
 
 
+def _get_feature_for_tokens(
+    token_texts_with_whitespace: list,
+    target_token_text: str,
+    feature_name: str
+) -> str:
+    tokens = [LayoutToken(text, whitespace=ws) for text, ws in token_texts_with_whitespace]
+    line = LayoutLine(tokens)
+    doc = LayoutDocument.for_blocks([LayoutBlock(lines=[line])])
+    gen = CitationDataGenerator(DEFAULT_DOCUMENT_FEATURES_CONTEXT)
+    idx = gen.feature_names.index(feature_name)
+    for item in gen.iter_model_data_for_layout_document(doc):
+        if item.data_line and item.data_line.split()[0] == target_token_text:
+            return item.data_line.split()[idx]
+    raise KeyError(f'token {target_token_text!r} not found')
+
+
 def _get_feature(token_text: str, feature_name: str) -> str:
     tokens = [LayoutToken(token_text)]
     line = LayoutLine(tokens)
@@ -31,6 +47,23 @@ class TestIsYear:
 
     def test_partial_number_gives_0(self):
         assert _get_feature('20', 'is_year') == '0'
+
+
+class TestIsHttp:
+    def test_http_starting_token_gives_1(self):
+        tokens = [('https', ''), ('://', ''), ('doi.org', ' '), ('other', ' ')]
+        assert _get_feature_for_tokens(tokens, 'https', 'is_http') == '1'
+
+    def test_token_within_url_span_gives_1(self):
+        tokens = [('https', ''), ('://', ''), ('doi.org', '/'), ('10.1234', ' ')]
+        assert _get_feature_for_tokens(tokens, 'doi.org', 'is_http') == '1'
+
+    def test_token_outside_url_gives_0(self):
+        tokens = [('https', ''), ('://', ''), ('doi.org', ' '), ('other', ' ')]
+        assert _get_feature_for_tokens(tokens, 'other', 'is_http') == '0'
+
+    def test_word_without_url_gives_0(self):
+        assert _get_feature('Lancet', 'is_http') == '0'
 
 
 class TestIsMonth:

--- a/tests/models/data_test.py
+++ b/tests/models/data_test.py
@@ -30,7 +30,8 @@ from sciencebeam_parser.models.data import (
 
 def _make_features(
     token_text: str,
-    app_features_context: AppFeaturesContext = AppFeaturesContext()
+    app_features_context: AppFeaturesContext = AppFeaturesContext(),
+    is_http: bool = False
 ) -> ContextAwareLayoutTokenFeatures:
     token = LayoutToken(token_text)
     line = LayoutLine.for_text(token_text)
@@ -39,7 +40,8 @@ def _make_features(
         layout_line=line,
         document_features_context=DocumentFeaturesContext(
             app_features_context=app_features_context
-        )
+        ),
+        is_http=is_http
     )
 
 
@@ -621,17 +623,15 @@ class TestContextAwareLayoutTokenFeaturesIsMonth:
 
 
 class TestContextAwareLayoutTokenFeaturesIsHttp:
-    def test_should_return_1_for_https_url(self):
-        assert _make_features('https://doi.org/10.1234/example').get_str_is_http() == '1'
+    def test_should_return_1_when_pre_computed_is_http_is_true(self):
+        features = _make_features('https://doi.org/10.1234/example', is_http=True)
+        assert features.get_str_is_http() == '1'
 
-    def test_should_return_1_for_http_url(self):
-        assert _make_features('http://example.com/path').get_str_is_http() == '1'
+    def test_should_return_0_when_pre_computed_is_http_is_false(self):
+        assert _make_features('http://example.com/path').get_str_is_http() == '0'
 
     def test_should_return_0_for_plain_word(self):
         assert _make_features('Innovation').get_str_is_http() == '0'
-
-    def test_should_return_0_for_url_without_scheme(self):
-        assert _make_features('example.com/path').get_str_is_http() == '0'
 
 
 class TestContextAwareLayoutTokenFeaturesIsCommonName:


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/88

GROBID's header and citation parsers pre-compute URL span positions using a regex over the full token text, then mark every token within a matched span as is_http=1 — not just the token that starts with "http". This matters for DOI suffixes like (20)30183-5 that are part of a URL span but don't themselves start with "http".

Add _get_http_token_indices() following the same pattern as _get_email_token_indices(): join tokens with their whitespace, run GROBID's urlPattern1 regex, and map character spans back to token indices. The is_http field on ContextAwareLayoutTokenFeatures is pre-computed alongside email and location_name indices, consolidating all_tokens into a single list reused for all three.

The reference segmenter uses a per-token approach in GROBID, so get_str_is_http_token_based() preserves that behaviour there while get_str_is_http() (used by header and citation) switches to span-based.