### PR TITLE
Fix sentence_token_relative_position to match GROBID's space-token counting

### DIFF
--- a/sciencebeam_parser/models/data.py
+++ b/sciencebeam_parser/models/data.py
@@ -605,8 +605,8 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
         previous_layout_token: Optional[LayoutToken] = None,
         token_index: int = 0,
         token_count: int = 0,
-        document_token_index: int = 0,
-        document_token_count: int = 0,
+        sentence_token_index: int = 0,
+        sentence_token_count: int = 0,
         line_index: int = 0,
         line_count: int = 0,
         concatenated_line_tokens_text: str = '',
@@ -628,8 +628,8 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
         self.document_features_context = document_features_context
         self.token_index = token_index
         self.token_count = token_count
-        self.document_token_index = document_token_index
-        self.document_token_count = document_token_count
+        self.sentence_token_index = sentence_token_index
+        self.sentence_token_count = sentence_token_count
         self.line_index = line_index
         self.line_count = line_count
         self.concatenated_line_tokens_text = concatenated_line_tokens_text
@@ -783,9 +783,8 @@ class ContextAwareLayoutTokenFeatures(  # pylint: disable=too-many-public-method
 
     def get_str_sentence_token_relative_position(self) -> str:
         return str(feature_linear_scaling_int(
-            # the document is currently the sentence view
-            self.document_token_index,
-            self.document_token_count,
+            self.sentence_token_index,
+            self.sentence_token_count,
             12
         ))
 
@@ -920,8 +919,7 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
         max_concatenated_line_tokens_length = max(
             concatenated_line_tokens_length_by_line_id.values()
         )
-        # GROBID-compatible line lengths: include inter-token whitespace and a newline,
-        # matching GROBID's accumulated.length() in its look-ahead (nn / currentLineLength).
+        # GROBID-compatible line lengths: include whitespace and a newline (nn / currentLineLength).
         grobid_line_length_by_line_id = {
             id(line): (
                 sum(len(t.text) + (1 if t.whitespace else 0) for t in line.tokens) + 1
@@ -931,7 +929,7 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
         }
         max_grobid_line_length = max(grobid_line_length_by_line_id.values())
         all_tokens = list(layout_document.iter_all_tokens())
-        document_token_count = len(all_tokens)
+        sentence_token_count = sum(1 + (1 if t.whitespace else 0) for t in all_tokens)
         # Pre-compute location name indices if a phrase match is configured.
         # This mirrors GROBID's HeaderParser which runs tokenPositionsLocationNames()
         # before the feature loop and marks tokens within matched spans.
@@ -949,6 +947,7 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
         http_token_indices = _get_http_token_indices(all_tokens)
         identifier_token_indices = _get_identifier_token_indices(all_tokens)
         document_token_index = 0
+        sentence_token_index = 0
         for block in layout_document.iter_all_blocks():
             line_indentation_status_feature.on_new_block()
             block_lines = block.lines
@@ -974,8 +973,8 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
                             document_features_context=self.document_features_context,
                             token_index=token_index,
                             token_count=token_count,
-                            document_token_index=document_token_index,
-                            document_token_count=document_token_count,
+                            sentence_token_index=sentence_token_index,
+                            sentence_token_count=sentence_token_count,
                             line_index=line_index,
                             line_count=line_count,
                             concatenated_line_tokens_text=concatenated_line_tokens_text,
@@ -997,4 +996,5 @@ class ContextAwareLayoutTokenModelDataGenerator(ModelDataGenerator):
                     # GROBID double-counts each space: space token contributes len(' ')+1 = 2.
                     if token.whitespace:
                         grobid_nn += 2 * len(token.whitespace)
+                    sentence_token_index += 1 + (1 if token.whitespace else 0)
                     document_token_index += 1

--- a/tests/models/citation/data_test.py
+++ b/tests/models/citation/data_test.py
@@ -108,3 +108,26 @@ class TestIsKnownIdentifier:
 
     def test_word_gives_0(self):
         assert _get_feature('Lancet', 'is_known_identifier') == '0'
+
+
+class TestSentenceTokenRelativePosition:
+    def test_single_token_gives_0(self):
+        # single token: sentence_token_count = 1, index = 0 → bin 0
+        assert _get_feature('Word', 'sentence_token_relative_position') == '0'
+
+    def test_last_of_three_space_separated_tokens_matches_grobid(self):
+        # GROBID: tokens = ["A"," ","B"," ","C"], sentenceLenth=5
+        # "C" is at n=4: floor(4/5*12) = floor(9.6) = 9
+        # sbeam (pre-fix) was: floor(2/3*12) = 8 — wrong
+        tokens = [('A', ' '), ('B', ' '), ('C', '')]
+        assert _get_feature_for_tokens(tokens, 'C', 'sentence_token_relative_position') == '9'
+
+    def test_middle_of_three_matches_grobid(self):
+        # "B" at n=2: floor(2/5*12) = floor(4.8) = 4 (same as pre-fix sbeam: floor(1/3*12) = 4)
+        tokens = [('A', ' '), ('B', ' '), ('C', '')]
+        assert _get_feature_for_tokens(tokens, 'B', 'sentence_token_relative_position') == '4'
+
+    def test_no_whitespace_tokens_unchanged(self):
+        # sub-tokens of a DOI with no whitespace: same as before
+        tokens = [('10', ''), ('.', ''), ('1016', ''), ('/', ''), ('abcde', '')]
+        assert _get_feature_for_tokens(tokens, '10', 'sentence_token_relative_position') == '0'


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/88

GROBID's FeaturesVectorCitation builds a token list that includes separate " " space tokens between word tokens. sentenceLenth = tokens.size() counts these, and n (the loop counter) increments for every token including spaces. So a word token's relative position reflects its index in the full list (word + space tokens), not its index among word tokens only.

sbeam's LayoutToken stores trailing whitespace as an attribute; iter_all_tokens() yields only word tokens. The previous code divided word-only indices by word-only counts, producing a different ratio for tokens followed by whitespace.

Fix: compute sentence_token_count as sum(1 + (1 if whitespace) for each token) and advance sentence_token_index by 2 for whitespace-followed tokens, mirroring GROBID's formula. "Sentence" follows standard CRF/sequence-labeling convention for an independently processed input sequence.