### PR TITLE
Apply GROBID-compatible sub-digit retokenization for citation model

### DIFF
--- a/sciencebeam_parser/models/citation/data.py
+++ b/sciencebeam_parser/models/citation/data.py
@@ -4,12 +4,15 @@ from sciencebeam_parser.models.data import (
     ContextAwareLayoutTokenFeatures,
     ContextAwareLayoutTokenModelDataGenerator,
     DocumentFeaturesContext,
-    FeatureDef
+    FeatureDef,
 )
 
 
 class CitationDataGenerator(ContextAwareLayoutTokenModelDataGenerator):
-    def __init__(self, document_features_context: DocumentFeaturesContext):
+    def __init__(
+        self,
+        document_features_context: DocumentFeaturesContext
+    ):
         super().__init__(document_features_context)
         self._feature_defs: List[FeatureDef[ContextAwareLayoutTokenFeatures]] = [
             FeatureDef('token_text', lambda f: f.token_text),

--- a/sciencebeam_parser/models/citation/model.py
+++ b/sciencebeam_parser/models/citation/model.py
@@ -1,21 +1,49 @@
 import logging
+from typing import List
+from typing_extensions import override
+
 from sciencebeam_parser.models.citation.training_data import (
     CitationTeiTrainingDataGenerator,
     CitationTrainingTeiParser
 )
 
 from sciencebeam_parser.models.data import (
+    AppFeaturesContext,
     DocumentFeaturesContext
 )
-from sciencebeam_parser.models.model import Model
+from sciencebeam_parser.models.model import LabeledLayoutToken, Model
 from sciencebeam_parser.models.citation.data import CitationDataGenerator
 from sciencebeam_parser.models.citation.extract import CitationSemanticExtractor
+from sciencebeam_parser.document.layout_document import LayoutDocument
+from sciencebeam_parser.utils.tokenizer import get_subdigit_tokenized_tokens
 
 
 LOGGER = logging.getLogger(__name__)
 
 
 class CitationModel(Model):
+    def retokenize_layout_documents(
+        self,
+        layout_documents: List[LayoutDocument]
+    ) -> List[LayoutDocument]:
+        if self.model_config.get('retokenize_subdigits', True):
+            return [
+                doc.retokenize(tokenize_fn=get_subdigit_tokenized_tokens)
+                for doc in layout_documents
+            ]
+        return layout_documents
+
+    @override
+    def predict_labels_for_layout_documents(
+        self,
+        layout_documents: List[LayoutDocument],
+        app_features_context: AppFeaturesContext
+    ) -> List[List[LabeledLayoutToken]]:
+        return super().predict_labels_for_layout_documents(
+            self.retokenize_layout_documents(layout_documents),
+            app_features_context=app_features_context
+        )
+
     def get_data_generator(
         self,
         document_features_context: DocumentFeaturesContext

--- a/sciencebeam_parser/processors/fulltext/processor.py
+++ b/sciencebeam_parser/processors/fulltext/processor.py
@@ -18,6 +18,7 @@ from sciencebeam_parser.models.model import LayoutDocumentLabelResult, Model
 from sciencebeam_parser.cv_models.cv_model import ComputerVisionModel
 from sciencebeam_parser.processors.fulltext.models import FullTextModels
 from sciencebeam_parser.utils.misc import iter_ids
+from sciencebeam_parser.utils.tokenizer import get_subdigit_tokenized_tokens
 
 from sciencebeam_parser.document.semantic_document import (
     SemanticAffiliationAddress,
@@ -618,6 +619,7 @@ class FullTextProcessor:
     ) -> Iterable[Union[SemanticReference, SemanticInvalidReference]]:
         layout_documents = [
             LayoutDocument.for_blocks([semantic_raw_reference.merged_block])
+            .retokenize(tokenize_fn=get_subdigit_tokenized_tokens)
             for semantic_raw_reference in semantic_raw_references
         ]
         labeled_layout_tokens_list = (

--- a/sciencebeam_parser/processors/fulltext/processor.py
+++ b/sciencebeam_parser/processors/fulltext/processor.py
@@ -18,7 +18,6 @@ from sciencebeam_parser.models.model import LayoutDocumentLabelResult, Model
 from sciencebeam_parser.cv_models.cv_model import ComputerVisionModel
 from sciencebeam_parser.processors.fulltext.models import FullTextModels
 from sciencebeam_parser.utils.misc import iter_ids
-from sciencebeam_parser.utils.tokenizer import get_subdigit_tokenized_tokens
 
 from sciencebeam_parser.document.semantic_document import (
     SemanticAffiliationAddress,
@@ -619,7 +618,6 @@ class FullTextProcessor:
     ) -> Iterable[Union[SemanticReference, SemanticInvalidReference]]:
         layout_documents = [
             LayoutDocument.for_blocks([semantic_raw_reference.merged_block])
-            .retokenize(tokenize_fn=get_subdigit_tokenized_tokens)
             for semantic_raw_reference in semantic_raw_references
         ]
         labeled_layout_tokens_list = (

--- a/sciencebeam_parser/service/api/routers/models.py
+++ b/sciencebeam_parser/service/api/routers/models.py
@@ -40,6 +40,7 @@ from sciencebeam_parser.document.semantic_document import (
 )
 from sciencebeam_parser.external.pdfalto.parser import parse_alto_root
 from sciencebeam_parser.external.pdfalto.wrapper import PdfAltoWrapper
+from sciencebeam_parser.models.citation.model import CitationModel
 from sciencebeam_parser.models.data import AppFeaturesContext, DocumentFeaturesContext
 from sciencebeam_parser.models.model import Model
 from sciencebeam_parser.service.api.dependencies import (
@@ -375,6 +376,8 @@ class AffiliationAddressModelRouterFactory(SegmentedModelRouterFactory):
 
 
 class CitationModelRouterFactory(SegmentedModelRouterFactory):
+    model: CitationModel
+
     def __init__(self, *args, reference_segmenter_model: Model, **kwargs):
         super().__init__(*args, **kwargs)
         self.reference_segmenter_model = reference_segmenter_model
@@ -400,12 +403,13 @@ class CitationModelRouterFactory(SegmentedModelRouterFactory):
             )).iter_by_type(SemanticRawReference)
         )
         LOGGER.info('semantic_raw_references count: %d', len(semantic_raw_references))
-        return [
+        docs = [
             LayoutDocument.for_blocks(
                 [semantic_raw_reference.view_by_type(SemanticRawReferenceText).merged_block]
             ).remove_empty_blocks()
             for semantic_raw_reference in semantic_raw_references
         ]
+        return self.model.retokenize_layout_documents(docs)
 
 
 class NameCitationModelRouterFactory(SegmentedModelRouterFactory):

--- a/sciencebeam_parser/utils/tokenizer.py
+++ b/sciencebeam_parser/utils/tokenizer.py
@@ -24,3 +24,12 @@ def iter_tokenized_tokens(text: str, keep_whitespace: bool = False) -> Iterable[
 
 def get_tokenized_tokens(text: str, **kwargs) -> List[str]:
     return list(iter_tokenized_tokens(text, **kwargs))
+
+
+# Matches GROBID's GrobidDefaultAnalyzer.retokenizeSubdigitsFromLayoutToken:
+# splits at letter→digit and digit→non-digit boundaries (e.g. e1006572 → e + 1006572).
+_SUBDIGIT_SPLIT_PATTERN = re.compile(r'(?<=[^\W\d_])(?=\d)|(?<=\d)(?=\D)')
+
+
+def get_subdigit_tokenized_tokens(text: str) -> List[str]:
+    return _SUBDIGIT_SPLIT_PATTERN.split(text)

--- a/tests/models/citation/model_test.py
+++ b/tests/models/citation/model_test.py
@@ -1,0 +1,87 @@
+from typing import List, Optional, Tuple
+from unittest.mock import MagicMock
+
+from sciencebeam_parser.document.layout_document import (
+    LayoutBlock,
+    LayoutDocument,
+    LayoutLine,
+    LayoutToken
+)
+from sciencebeam_parser.models.data import DEFAULT_APP_FEATURES_CONTEXT
+from sciencebeam_parser.models.citation.model import CitationModel
+from sciencebeam_parser.models.model_impl import ModelImpl
+
+
+class CapturingModelImpl(ModelImpl):
+    def __init__(self):
+        self.received_texts: List[List[str]] = []
+
+    def predict_labels(
+        self,
+        texts: List[List[str]],
+        features: List[List[List[str]]],
+        output_format: Optional[str] = None
+    ) -> List[List[Tuple[str, str]]]:
+        self.received_texts = texts
+        return [[(t, '<other>') for t in doc] for doc in texts]
+
+    def preload(self):
+        pass
+
+
+def _make_citation_model(retokenize_subdigits=None) -> Tuple[CitationModel, CapturingModelImpl]:
+    impl = CapturingModelImpl()
+    impl_factory = MagicMock(return_value=impl)
+    model_config: dict = {}
+    if retokenize_subdigits is not None:
+        model_config['retokenize_subdigits'] = retokenize_subdigits
+    model = CitationModel(impl_factory, model_config=model_config)
+    model.preload()
+    return model, impl
+
+
+def _doc_with_tokens(*token_texts: str) -> LayoutDocument:
+    tokens = [LayoutToken(t) for t in token_texts]
+    return LayoutDocument.for_blocks([LayoutBlock(lines=[LayoutLine(tokens)])])
+
+
+class TestCitationModelSubdigitRetokenization:
+    def test_mixed_token_split_by_default(self):
+        model, impl = _make_citation_model()
+        model.predict_labels_for_layout_documents(
+            [_doc_with_tokens('e1006572')],
+            DEFAULT_APP_FEATURES_CONTEXT
+        )
+        assert impl.received_texts == [['e', '1006572']]
+
+    def test_digit_then_letter_split_by_default(self):
+        model, impl = _make_citation_model()
+        model.predict_labels_for_layout_documents(
+            [_doc_with_tokens('295X')],
+            DEFAULT_APP_FEATURES_CONTEXT
+        )
+        assert impl.received_texts == [['295', 'X']]
+
+    def test_pure_alpha_token_unchanged(self):
+        model, impl = _make_citation_model()
+        model.predict_labels_for_layout_documents(
+            [_doc_with_tokens('Lancet')],
+            DEFAULT_APP_FEATURES_CONTEXT
+        )
+        assert impl.received_texts == [['Lancet']]
+
+    def test_retokenize_disabled_leaves_token_unsplit(self):
+        model, impl = _make_citation_model(retokenize_subdigits=False)
+        model.predict_labels_for_layout_documents(
+            [_doc_with_tokens('e1006572')],
+            DEFAULT_APP_FEATURES_CONTEXT
+        )
+        assert impl.received_texts == [['e1006572']]
+
+    def test_retokenize_explicitly_enabled(self):
+        model, impl = _make_citation_model(retokenize_subdigits=True)
+        model.predict_labels_for_layout_documents(
+            [_doc_with_tokens('e1006572')],
+            DEFAULT_APP_FEATURES_CONTEXT
+        )
+        assert impl.received_texts == [['e', '1006572']]

--- a/tests/utils/tokenizer_test.py
+++ b/tests/utils/tokenizer_test.py
@@ -1,4 +1,30 @@
-from sciencebeam_parser.utils.tokenizer import iter_tokenized_tokens
+from sciencebeam_parser.utils.tokenizer import (
+    get_subdigit_tokenized_tokens,
+    iter_tokenized_tokens
+)
+
+
+class TestGetSubdigitTokenizedTokens:
+    def test_letter_then_digit_splits(self):
+        # e.g. DOI suffix 'e1006572' → ['e', '1006572']
+        assert get_subdigit_tokenized_tokens('e1006572') == ['e', '1006572']
+
+    def test_digit_then_letter_splits(self):
+        # e.g. '295X' → ['295', 'X']
+        assert get_subdigit_tokenized_tokens('295X') == ['295', 'X']
+
+    def test_letter_then_digit_then_letter_splits_twice(self):
+        # e.g. 'j8sxz' → ['j', '8', 'sxz']
+        assert get_subdigit_tokenized_tokens('j8sxz') == ['j', '8', 'sxz']
+
+    def test_all_letters_unchanged(self):
+        assert get_subdigit_tokenized_tokens('Lancet') == ['Lancet']
+
+    def test_all_digits_unchanged(self):
+        assert get_subdigit_tokenized_tokens('2020') == ['2020']
+
+    def test_xge_prefix_splits(self):
+        assert get_subdigit_tokenized_tokens('xge0000511') == ['xge', '0000511']
 
 
 class TestIterTokenizedTokens:


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/88

Splits tokens at letter→digit and digit→non-digit boundaries (e.g.
e1006572 → e + 1006572) to match GROBID's retokenizeSubdigitsFromLayoutToken,
applied only in the citation model. Logic is centralised in
CitationModel.retokenize_layout_documents, called from both the processor
path and the API model data endpoint. Training data generation is excluded
as TEI tokens are already split by GROBID. Configurable via
retokenize_subdigits in model_config (default: true).
