### PR TITLE
Improve gold failure analysis

### DIFF
--- a/benchmarks/analyze_gold_failures/_modes.py
+++ b/benchmarks/analyze_gold_failures/_modes.py
@@ -49,6 +49,23 @@ def _normalize(text: str) -> str:
     return re.sub(r'\s+', '', text)
 
 
+def _normalize_for_presence(text: str) -> str:
+    """Lowercase variant of _normalize used for presence detection only.
+
+    Presence checks (is this value anywhere in the raw TEI?) should be
+    case-insensitive so that ALL-CAPS PDF renderings of a title are not
+    mistakenly classified as NOT_IN_RAW_TEXT.  Similarity scoring still
+    uses _normalize (case-sensitive) so case differences surface in the
+    PARTIAL_WRONG section and near-miss classification.
+    """
+    return _normalize(text).lower()
+
+
+def _strip_xml_tags(text: str) -> str:
+    """Replace each XML/HTML tag with a space to preserve word boundaries."""
+    return re.sub(r'<[^>]+>', ' ', text)
+
+
 def _in_raw_fuzzy(norm_value: str, norm_raw: str) -> bool:
     """Exact substring match, with a sliding-window fallback for single-char differences.
 
@@ -77,21 +94,30 @@ def _parse_pipe_separated(text: Optional[str]) -> List[str]:
     return [v.strip() for v in text.split(' | ') if v.strip()]
 
 
-def _best_edit_sim(gold: str, candidates: List[str]) -> Tuple[Optional[str], float]:
+def _best_edit_sim(
+    gold: str,
+    candidates: List[str],
+    case_insensitive: bool = False,
+) -> Tuple[Optional[str], float]:
     if not candidates:
         return None, 0.0
     norm_gold = _normalize(gold)
+    if case_insensitive:
+        norm_gold = norm_gold.lower()
     best_match: Optional[str] = None
     best_sim = 0.0
     for candidate in candidates:
-        sim = SequenceMatcher(None, norm_gold, _normalize(candidate)).ratio()
+        norm_cand = _normalize(candidate)
+        if case_insensitive:
+            norm_cand = norm_cand.lower()
+        sim = SequenceMatcher(None, norm_gold, norm_cand).ratio()
         if sim > best_sim:
             best_sim = sim
             best_match = candidate
     return best_match, best_sim
 
 
-def assign_failure_modes(
+def assign_failure_modes(  # pylint: disable=too-many-locals
     gold_values: List[str],
     raw_tei_text: Optional[str],
     sb_field_text: Optional[str],
@@ -108,23 +134,34 @@ def assign_failure_modes(
         similarity_threshold: Minimum SequenceMatcher ratio to consider a value
             correctly extracted (default 0.8).
     """
-    norm_raw = _normalize(raw_tei_text) if raw_tei_text else ''
-    norm_sb_full = _normalize(sb_field_text) if sb_field_text else ''
+    # Case-insensitive normalised strings for presence detection only.
+    # ALL-CAPS PDF renderings of titles must not be classified as NOT_IN_RAW_TEXT.
+    norm_raw = _normalize_for_presence(_strip_xml_tags(raw_tei_text)) if raw_tei_text else ''
+    norm_sb_full = _normalize_for_presence(sb_field_text) if sb_field_text else ''
     sb_values = _parse_pipe_separated(sb_field_text)
 
     results = []
     for value in gold_values:
-        norm_value = _normalize(value)
+        norm_value_presence = _normalize_for_presence(value)
 
-        in_raw = bool(norm_value and _in_raw_fuzzy(norm_value, norm_raw))
-        in_sb_field = bool(norm_value and _in_raw_fuzzy(norm_value, norm_sb_full))
+        in_raw = bool(norm_value_presence and _in_raw_fuzzy(norm_value_presence, norm_raw))
+        in_sb_field = bool(
+            norm_value_presence and _in_raw_fuzzy(norm_value_presence, norm_sb_full)
+        )
 
         if not in_raw:
+            # Even though the gold value was not found in the raw text, record whatever
+            # was extracted into the target field so the report can show it.  The
+            # similarity score is computed case-insensitively so that ALL-CAPS PDF
+            # renderings still show high similarity rather than landing in "absent".
+            nr_match, nr_sim = _best_edit_sim(value, sb_values, case_insensitive=True)
             results.append(GoldValueResult(
                 value=value,
                 mode=FailureMode.NOT_IN_RAW_TEXT,
                 in_raw=False,
                 in_sb_field=in_sb_field,
+                best_sb_match=nr_match,
+                best_sb_similarity=round(nr_sim, 3) if nr_match is not None else None,
             ))
         elif not in_sb_field:
             results.append(GoldValueResult(

--- a/benchmarks/analyze_gold_failures/_modes.py
+++ b/benchmarks/analyze_gold_failures/_modes.py
@@ -66,26 +66,47 @@ def _strip_xml_tags(text: str) -> str:
     return re.sub(r'<[^>]+>', ' ', text)
 
 
-def _in_raw_fuzzy(norm_value: str, norm_raw: str) -> bool:
-    """Exact substring match, with a sliding-window fallback for single-char differences.
+def _find_best_raw_window(norm_value: str, norm_raw: str) -> Tuple[bool, float]:
+    """Return (passes_threshold, best_similarity) for norm_value against norm_raw.
 
-    Uses a fast character-mismatch counter (not SequenceMatcher) so the per-window
-    cost is O(n) rather than O(n²). Allows 1 mismatch per 30 characters, minimum 1.
-    Only activates for values of 8+ characters; shorter strings require exact match
-    to avoid false positives.
+    Scans every fixed-length window of norm_raw using a fast character-mismatch
+    counter (O(n·m), not SequenceMatcher) to find the best-matching position, then
+    computes a proper SequenceMatcher ratio on that window to get a meaningful
+    similarity score that handles insertions/deletions.
+
+    passes_threshold: True when the best window has ≤ max(1, n//30) mismatches
+                      (same tolerance as the old _in_raw_fuzzy).
+    best_similarity:  SequenceMatcher ratio in [0, 1] of the best window found.
+                      1.0 for an exact substring match; lower when content differs.
     """
+    if not norm_value or not norm_raw:
+        return False, 0.0
     if norm_value in norm_raw:
-        return True
+        return True, 1.0
     n = len(norm_value)
     if n < 8:
-        return False
+        return False, 0.0
+    raw_len = len(norm_raw)
+    if raw_len < n:
+        sim = SequenceMatcher(None, norm_value, norm_raw).ratio()
+        return False, round(sim, 3)
     max_mismatches = max(1, n // 30)
-    for start in range(len(norm_raw) - n + 1):
-        window = norm_raw[start:start + n]
-        mismatches = sum(a != b for a, b in zip(norm_value, window))
-        if mismatches <= max_mismatches:
-            return True
-    return False
+    best_start = 0
+    best_mismatches = n
+    for start in range(raw_len - n + 1):
+        mismatches = sum(a != b for a, b in zip(norm_value, norm_raw[start:start + n]))
+        if mismatches < best_mismatches:
+            best_mismatches = mismatches
+            best_start = start
+    best_window = norm_raw[best_start:best_start + n]
+    sim = SequenceMatcher(None, norm_value, best_window).ratio()
+    return best_mismatches <= max_mismatches, round(sim, 3)
+
+
+def _in_raw_fuzzy(norm_value: str, norm_raw: str) -> bool:
+    """Presence-only wrapper over _find_best_raw_window."""
+    in_raw, _ = _find_best_raw_window(norm_value, norm_raw)
+    return in_raw
 
 
 def _parse_pipe_separated(text: Optional[str]) -> List[str]:
@@ -144,16 +165,18 @@ def assign_failure_modes(  # pylint: disable=too-many-locals
     for value in gold_values:
         norm_value_presence = _normalize_for_presence(value)
 
-        in_raw = bool(norm_value_presence and _in_raw_fuzzy(norm_value_presence, norm_raw))
+        in_raw, best_raw_sim = (
+            _find_best_raw_window(norm_value_presence, norm_raw)
+            if norm_value_presence else (False, 0.0)
+        )
         in_sb_field = bool(
             norm_value_presence and _in_raw_fuzzy(norm_value_presence, norm_sb_full)
         )
 
         if not in_raw:
-            # Even though the gold value was not found in the raw text, record whatever
-            # was extracted into the target field so the report can show it.  The
-            # similarity score is computed case-insensitively so that ALL-CAPS PDF
-            # renderings still show high similarity rather than landing in "absent".
+            # Record whatever was extracted so the report can show it alongside the
+            # raw-text similarity.  Both similarity scores are case-insensitive so
+            # ALL-CAPS PDF renderings appear close rather than unrelated.
             nr_match, nr_sim = _best_edit_sim(value, sb_values, case_insensitive=True)
             results.append(GoldValueResult(
                 value=value,
@@ -162,6 +185,7 @@ def assign_failure_modes(  # pylint: disable=too-many-locals
                 in_sb_field=in_sb_field,
                 best_sb_match=nr_match,
                 best_sb_similarity=round(nr_sim, 3) if nr_match is not None else None,
+                best_raw_similarity=best_raw_sim,
             ))
         elif not in_sb_field:
             results.append(GoldValueResult(
@@ -171,7 +195,9 @@ def assign_failure_modes(  # pylint: disable=too-many-locals
                 in_sb_field=False,
             ))
         else:
-            best_match, best_sim = _best_edit_sim(value, sb_values)
+            # Use case-insensitive similarity so ALL-CAPS extracted values score
+            # correctly rather than appearing as near-zero matches.
+            best_match, best_sim = _best_edit_sim(value, sb_values, case_insensitive=True)
             mode = (
                 FailureMode.CORRECT
                 if best_sim >= similarity_threshold

--- a/benchmarks/analyze_gold_failures/_report.py
+++ b/benchmarks/analyze_gold_failures/_report.py
@@ -280,6 +280,59 @@ def _see_all_link(mode: FailureMode, total: int) -> str:
     return f'_(showing {SAMPLE_SIZE} of {total} — [see all]({filename}))_'
 
 
+_NR_TABLE_HEADER_NARROW = ['| Doc | Corpus | Gold value |', '| --- | --- | --- |']
+_NR_TABLE_HEADER_WIDE = [
+    '| Doc | Corpus | Gold value | Extracted | Sim |',
+    '| --- | --- | --- | --- | ---: |',
+]
+
+# Similarity threshold for treating a NOT_IN_RAW_TEXT result as a gold/PDF form
+# mismatch rather than a genuine absence.  Above this the extracted field value is
+# clearly the same content rendered differently; below it the two strings are
+# unrelated and the value is treated as truly absent.
+_NR_DIFF_FORM_THRESHOLD = 0.6
+
+
+def _render_not_in_raw_rows(
+    examples: List[Tuple[str, str, GoldValueResult]],
+    wide: bool,
+) -> List[str]:
+    lines = []
+    for corpus, record_id, result in examples:
+        if wide:
+            extracted = result.best_sb_match or '—'
+            sim = (
+                f'{result.best_sb_similarity:.2f}'
+                if result.best_sb_similarity is not None else '—'
+            )
+            lines.append(
+                f'| {record_id} | {corpus} | {result.value} | {extracted} | {sim} |'
+            )
+        else:
+            lines.append(f'| {record_id} | {corpus} | {result.value} |')
+    return lines
+
+
+def _split_not_in_raw(
+    examples: List[Tuple[str, str, GoldValueResult]],
+) -> Tuple[List[Tuple[str, str, GoldValueResult]], List[Tuple[str, str, GoldValueResult]]]:
+    """Partition NOT_IN_RAW_TEXT examples into (absent, diff_form).
+
+    diff_form: best_sb_similarity >= _NR_DIFF_FORM_THRESHOLD — the text was
+               extracted as the correct field type but in a different form.
+    absent:    everything else — no similar extraction found, or nothing extracted.
+    """
+    absent, diff_form = [], []
+    for item in examples:
+        _, _, result = item
+        sim = result.best_sb_similarity or 0.0
+        if sim >= _NR_DIFF_FORM_THRESHOLD:
+            diff_form.append(item)
+        else:
+            absent.append(item)
+    return absent, diff_form
+
+
 def _render_not_in_raw_section(
     agg: FailureModeAggregate,
     summary_total: int,
@@ -290,22 +343,49 @@ def _render_not_in_raw_section(
         f' {agg.docs_affected} doc(s),'
         f' {_pct(agg.total_values, summary_total)})',
         '',
-        '_Gold values absent from raw ScienceBeam TEI output. '
-        'No model training change is likely to recover these directly._',
-        '',
     ]
     examples = agg.examples
     if not examples:
         lines.append('_None._')
-    else:
-        sample = examples[:SAMPLE_SIZE]
-        lines += ['| Doc | Corpus | Gold value |', '| --- | --- | --- |']
-        for corpus, record_id, result in sample:
-            lines.append(f'| {record_id} | {corpus} | {result.value} |')
-        if len(examples) > SAMPLE_SIZE:
-            lines.append('')
-            lines.append(_see_all_link(FailureMode.NOT_IN_RAW_TEXT, len(examples)))
-    lines.append('')
+        lines.append('')
+        return lines
+
+    absent, diff_form = _split_not_in_raw(examples)
+
+    if absent:
+        lines += [
+            f'### Absent from raw text ({len(absent)} value(s))',
+            '',
+            '_Gold values not found in the raw ScienceBeam TEI output and no similar '
+            'value was extracted into the field. '
+            'This may indicate the value is missing from the PDF, or that raw text '
+            'extraction renders it too differently to detect. '
+            'Model training is unlikely to recover these._',
+            '',
+        ]
+        sample = absent[:SAMPLE_SIZE]
+        lines += _NR_TABLE_HEADER_NARROW + _render_not_in_raw_rows(sample, wide=False)
+        if len(absent) > SAMPLE_SIZE:
+            lines += ['', _see_all_link(FailureMode.NOT_IN_RAW_TEXT, len(examples))]
+        lines.append('')
+
+    if diff_form:
+        lines += [
+            f'### Extracted with different form ({len(diff_form)} value(s))',
+            '',
+            '_The gold value was not found in the raw text, but a similar value was '
+            'extracted into the field. '
+            'This is a gold-label / PDF-rendering mismatch '
+            '(e.g. different wording, extra words, ALL CAPS) rather than a model error. '
+            'Consider normalising the gold labels or the extraction post-processing._',
+            '',
+        ]
+        sample = diff_form[:SAMPLE_SIZE]
+        lines += _NR_TABLE_HEADER_WIDE + _render_not_in_raw_rows(sample, wide=True)
+        if len(diff_form) > SAMPLE_SIZE:
+            lines += ['', _see_all_link(FailureMode.NOT_IN_RAW_TEXT, len(examples))]
+        lines.append('')
+
     return lines
 
 
@@ -545,16 +625,24 @@ def _render_not_in_raw_full(
     summary_total: int,
 ) -> str:
     label = FAILURE_MODE_LABEL[FailureMode.NOT_IN_RAW_TEXT]
+    absent, diff_form = _split_not_in_raw(agg.examples)
     lines = [
         f'# {label} — full list',
         f'_{agg.total_values} value(s), {_pct(agg.total_values, summary_total)} of gold_',
         '',
-        '| Doc | Corpus | Gold value |',
-        '| --- | --- | --- |',
     ]
-    for corpus, record_id, result in agg.examples:
-        lines.append(f'| {record_id} | {corpus} | {result.value} |')
-    lines.append('')
+    if absent:
+        lines += [
+            f'## Absent from raw text ({len(absent)} value(s))',
+            '',
+        ] + _NR_TABLE_HEADER_NARROW + _render_not_in_raw_rows(absent, wide=False)
+        lines.append('')
+    if diff_form:
+        lines += [
+            f'## Extracted with different form ({len(diff_form)} value(s))',
+            '',
+        ] + _NR_TABLE_HEADER_WIDE + _render_not_in_raw_rows(diff_form, wide=True)
+        lines.append('')
     return '\n'.join(lines)
 
 

--- a/benchmarks/analyze_gold_failures/_report.py
+++ b/benchmarks/analyze_gold_failures/_report.py
@@ -280,10 +280,13 @@ def _see_all_link(mode: FailureMode, total: int) -> str:
     return f'_(showing {SAMPLE_SIZE} of {total} — [see all]({filename}))_'
 
 
-_NR_TABLE_HEADER_NARROW = ['| Doc | Corpus | Gold value |', '| --- | --- | --- |']
+_NR_TABLE_HEADER_NARROW = [
+    '| Doc | Corpus | Gold value | Raw sim |',
+    '| --- | --- | --- | ---: |',
+]
 _NR_TABLE_HEADER_WIDE = [
-    '| Doc | Corpus | Gold value | Extracted | Sim |',
-    '| --- | --- | --- | --- | ---: |',
+    '| Doc | Corpus | Gold value | Raw sim | Extracted | Extr sim |',
+    '| --- | --- | --- | ---: | --- | ---: |',
 ]
 
 # Similarity threshold for treating a NOT_IN_RAW_TEXT result as a gold/PDF form
@@ -299,17 +302,22 @@ def _render_not_in_raw_rows(
 ) -> List[str]:
     lines = []
     for corpus, record_id, result in examples:
+        raw_sim = (
+            f'{result.best_raw_similarity:.2f}'
+            if result.best_raw_similarity is not None else '—'
+        )
         if wide:
             extracted = result.best_sb_match or '—'
-            sim = (
+            extr_sim = (
                 f'{result.best_sb_similarity:.2f}'
                 if result.best_sb_similarity is not None else '—'
             )
             lines.append(
-                f'| {record_id} | {corpus} | {result.value} | {extracted} | {sim} |'
+                f'| {record_id} | {corpus} | {result.value}'
+                f' | {raw_sim} | {extracted} | {extr_sim} |'
             )
         else:
-            lines.append(f'| {record_id} | {corpus} | {result.value} |')
+            lines.append(f'| {record_id} | {corpus} | {result.value} | {raw_sim} |')
     return lines
 
 

--- a/benchmarks/analyze_gold_failures/_report.py
+++ b/benchmarks/analyze_gold_failures/_report.py
@@ -289,10 +289,11 @@ _NR_TABLE_HEADER_WIDE = [
     '| --- | --- | --- | ---: | --- | ---: |',
 ]
 
-# Similarity threshold for treating a NOT_IN_RAW_TEXT result as a gold/PDF form
-# mismatch rather than a genuine absence.  Above this the extracted field value is
-# clearly the same content rendered differently; below it the two strings are
-# unrelated and the value is treated as truly absent.
+# Raw-text similarity threshold for treating a NOT_IN_RAW_TEXT result as a
+# gold/PDF wording mismatch rather than a genuine absence.  Above this the best
+# fixed-length window in the source PDF is clearly the same content in a different
+# form (ALL CAPS, extra/missing words, reordered subtitle); below it the source
+# PDF has no recognisable match and the value is treated as truly absent.
 _NR_DIFF_FORM_THRESHOLD = 0.6
 
 
@@ -326,14 +327,18 @@ def _split_not_in_raw(
 ) -> Tuple[List[Tuple[str, str, GoldValueResult]], List[Tuple[str, str, GoldValueResult]]]:
     """Partition NOT_IN_RAW_TEXT examples into (absent, diff_form).
 
-    diff_form: best_sb_similarity >= _NR_DIFF_FORM_THRESHOLD — the text was
-               extracted as the correct field type but in a different form.
-    absent:    everything else — no similar extraction found, or nothing extracted.
+    diff_form: max(best_raw_similarity, best_sb_similarity) >= _NR_DIFF_FORM_THRESHOLD.
+               Either the source PDF has similar content (raw sim), or the model
+               extracted something similar (extr sim — evidence the content is in the
+               PDF even if the fixed-window scan missed it, e.g. word-order swaps).
+    absent:    everything else — no recognisable match in either the PDF text or the
+               extracted field.  The value may be genuinely absent, incorrectly
+               annotated, or from a different version of the paper.
     """
     absent, diff_form = [], []
     for item in examples:
         _, _, result = item
-        sim = result.best_sb_similarity or 0.0
+        sim = max(result.best_raw_similarity or 0.0, result.best_sb_similarity or 0.0)
         if sim >= _NR_DIFF_FORM_THRESHOLD:
             diff_form.append(item)
         else:
@@ -362,29 +367,29 @@ def _render_not_in_raw_section(
 
     if absent:
         lines += [
-            f'### Absent from raw text ({len(absent)} value(s))',
+            f'### Absent from source PDF ({len(absent)} value(s))',
             '',
-            '_Gold values not found in the raw ScienceBeam TEI output and no similar '
-            'value was extracted into the field. '
-            'This may indicate the value is missing from the PDF, or that raw text '
-            'extraction renders it too differently to detect. '
+            '_Neither the source PDF text nor the extracted field contains a recognisable '
+            'match for the gold value (both raw and extracted similarity < 0.6). '
+            'The value may be genuinely absent from this document, incorrectly '
+            'annotated, or from a different version of the paper. '
             'Model training is unlikely to recover these._',
             '',
         ]
         sample = absent[:SAMPLE_SIZE]
-        lines += _NR_TABLE_HEADER_NARROW + _render_not_in_raw_rows(sample, wide=False)
+        lines += _NR_TABLE_HEADER_WIDE + _render_not_in_raw_rows(sample, wide=True)
         if len(absent) > SAMPLE_SIZE:
             lines += ['', _see_all_link(FailureMode.NOT_IN_RAW_TEXT, len(examples))]
         lines.append('')
 
     if diff_form:
         lines += [
-            f'### Extracted with different form ({len(diff_form)} value(s))',
+            f'### Present in PDF as different form ({len(diff_form)} value(s))',
             '',
-            '_The gold value was not found in the raw text, but a similar value was '
-            'extracted into the field. '
-            'This is a gold-label / PDF-rendering mismatch '
-            '(e.g. different wording, extra words, ALL CAPS) rather than a model error. '
+            '_A similar form of the gold value exists in the source PDF '
+            '(raw similarity ≥ 0.6) but does not match verbatim — '
+            'e.g. ALL CAPS rendering, extra or missing words, reordered subtitle. '
+            'This is a gold-label / PDF-rendering mismatch rather than a model error. '
             'Consider normalising the gold labels or the extraction post-processing._',
             '',
         ]
@@ -641,13 +646,13 @@ def _render_not_in_raw_full(
     ]
     if absent:
         lines += [
-            f'## Absent from raw text ({len(absent)} value(s))',
+            f'## Absent from source PDF ({len(absent)} value(s))',
             '',
-        ] + _NR_TABLE_HEADER_NARROW + _render_not_in_raw_rows(absent, wide=False)
+        ] + _NR_TABLE_HEADER_WIDE + _render_not_in_raw_rows(absent, wide=True)
         lines.append('')
     if diff_form:
         lines += [
-            f'## Extracted with different form ({len(diff_form)} value(s))',
+            f'## Present in PDF as different form ({len(diff_form)} value(s))',
             '',
         ] + _NR_TABLE_HEADER_WIDE + _render_not_in_raw_rows(diff_form, wide=True)
         lines.append('')

--- a/benchmarks/analyze_gold_failures/_screenshots.py
+++ b/benchmarks/analyze_gold_failures/_screenshots.py
@@ -83,15 +83,18 @@ def _iter_element_text(el: ElementTree.Element) -> str:
 
 
 def _text_similarity(a: str, b: str) -> float:
-    """Simple overlap ratio: shared characters / max length."""
+    """Similarity of a matched substring: 1.0 when one string contains the other verbatim.
+
+    Score = len(gold) / max(len(gold), len(matched_text)).  For a verbatim substring
+    match, matched_text IS the gold value, so the score is 1.0 regardless of how much
+    extra text the element contains.  Ranking between elements that all score 1.0 is
+    left to context scoring (sibling matching).
+    """
     if not a or not b:
         return 0.0
     longer, shorter = (a, b) if len(a) >= len(b) else (b, a)
-    # Score = proportion of the gold value covered by the element text.
-    # An element whose normalised text equals the gold value scores 1.0;
-    # an element containing it as a tiny substring scores close to 0.
     if shorter in longer:
-        return len(shorter) / max(len(longer), 1)
+        return 1.0
     return 0.0
 
 

--- a/benchmarks/analyze_gold_failures/_types.py
+++ b/benchmarks/analyze_gold_failures/_types.py
@@ -35,6 +35,10 @@ class GoldValueResult:
     in_sb_field: bool
     best_sb_match: Optional[str] = None
     best_sb_similarity: Optional[float] = None
+    # Similarity of the best-matching fixed-length window in the raw TEI text.
+    # Only populated for NOT_IN_RAW_TEXT results; implicitly ~1.0 for all other modes
+    # (since in_raw=True guarantees the gold appears in the raw text).
+    best_raw_similarity: Optional[float] = None
 
 
 @dataclass

--- a/benchmarks/analyze_gold_failures/tests/test_modes.py
+++ b/benchmarks/analyze_gold_failures/tests/test_modes.py
@@ -1,11 +1,38 @@
 from __future__ import annotations
 
-from benchmarks.analyze_gold_failures._modes import assign_failure_modes
+from benchmarks.analyze_gold_failures._modes import assign_failure_modes, _find_best_raw_window
 from benchmarks.analyze_gold_failures._types import FailureMode
 
 
 RAW_TEXT = 'Introduction Methods Results Discussion Conclusion'
 SB_FIELD = 'Introduction | Methods | Results'
+
+
+class TestFindBestRawWindow:
+    def test_exact_match_returns_true_and_1(self):
+        in_raw, sim = _find_best_raw_window('methods', 'introduction methods results')
+        assert in_raw is True
+        assert sim == 1.0
+
+    def test_absent_returns_false_and_low_sim(self):
+        in_raw, sim = _find_best_raw_window('acknowledgements', 'introduction methods results')
+        assert in_raw is False
+        assert sim < 0.5
+
+    def test_best_sim_is_high_for_near_match(self):
+        # Gold has an extra word compared to the raw window — should still score high
+        in_raw, sim = _find_best_raw_window(
+            'isaudiovisualmethodbetterthantraditionalstudents',
+            'isaudiovisualmethodthantraditionalstudents',
+        )
+        assert in_raw is False
+        assert sim >= 0.8
+
+    def test_short_value_requires_exact_match(self):
+        # Values under 8 chars: fuzzy disabled, no sim computed
+        in_raw, sim = _find_best_raw_window('abc', 'abx introduction methods')
+        assert in_raw is False
+        assert sim == 0.0
 
 
 class TestAssignFailureModes:  # pylint: disable=too-many-public-methods
@@ -144,6 +171,38 @@ class TestAssignFailureModes:  # pylint: disable=too-many-public-methods
         results = assign_failure_modes([gold], raw, None)
         assert results[0].mode == FailureMode.NOT_IN_RAW_TEXT
         assert results[0].best_sb_match is None
+
+    def test_all_caps_extracted_is_correct_not_partial_wrong(self):
+        # When the extracted value is ALL CAPS but gold is mixed-case, case-insensitive
+        # similarity should be ~1.0, so the result is CORRECT not PARTIAL_WRONG.
+        raw = 'ETHNO-MEDICO BOTANICAL STUDY AMONG THE FOUR INDIGENOUS COMMUNITIES'
+        gold = 'Ethno-medico botanical study among the four indigenous communities'
+        sb_field = 'ETHNO-MEDICO BOTANICAL STUDY AMONG THE FOUR INDIGENOUS COMMUNITIES'
+        results = assign_failure_modes([gold], raw, sb_field)
+        assert results[0].mode == FailureMode.CORRECT
+        assert results[0].best_sb_similarity is not None
+        assert results[0].best_sb_similarity >= 0.99
+
+    def test_not_in_raw_populates_best_raw_similarity(self):
+        # best_raw_similarity reflects how closely the gold matches the raw PDF text.
+        # A value that is verbatim in the raw text scores 1.0; a truly absent value
+        # scores near 0.
+        raw = 'some completely unrelated document text about nothing relevant'
+        gold = 'A title that does not appear anywhere in this document'
+        results = assign_failure_modes([gold], raw, None)
+        assert results[0].mode == FailureMode.NOT_IN_RAW_TEXT
+        assert results[0].best_raw_similarity is not None
+        assert results[0].best_raw_similarity < 0.5
+
+    def test_not_in_raw_best_raw_similarity_high_for_near_match(self):
+        # When gold has a small content difference from the PDF (e.g. an extra word),
+        # best_raw_similarity should be high, indicating a gold/PDF form mismatch.
+        raw = 'IS AUDIO VISUAL METHOD THAN TRADITIONAL FOR MEDICAL STUDENTS'
+        gold = 'is audio visual method better than traditional for medical students'
+        results = assign_failure_modes([gold], raw, None)
+        assert results[0].mode == FailureMode.NOT_IN_RAW_TEXT
+        assert results[0].best_raw_similarity is not None
+        assert results[0].best_raw_similarity >= 0.8
 
     def test_all_caps_title_is_not_not_in_raw_text(self):
         # PDF rendering may produce ALL-CAPS titles.  Presence detection must be

--- a/benchmarks/analyze_gold_failures/tests/test_modes.py
+++ b/benchmarks/analyze_gold_failures/tests/test_modes.py
@@ -214,10 +214,50 @@ class TestAssignFailureModes:  # pylint: disable=too-many-public-methods
         assert results[0].in_raw is True
         assert results[0].mode != FailureMode.NOT_IN_RAW_TEXT
 
+    def test_not_in_raw_high_raw_sim_low_extracted_sim(self):
+        # Gold has an extra word absent from the PDF title, so in_raw=False.
+        # best_raw_similarity should still be high (the bulk of the text matches),
+        # while best_sb_similarity is low (model extracted something unrelated).
+        # The split uses max(raw_sim, extr_sim) so the high raw_sim is sufficient
+        # to place this in "Present in PDF as different form".
+        raw = (
+            'IS AUDIO VISUAL METHOD THAN TRADITIONAL FOR MEDICAL STUDENTS A SURVEY REPORT'
+        )
+        gold = (
+            'is audio visual method better than traditional for medical students a survey report'
+        )
+        sb_field = 'Completely unrelated extracted text from a different section'
+        results = assign_failure_modes([gold], raw, sb_field)
+        assert results[0].mode == FailureMode.NOT_IN_RAW_TEXT
+        assert results[0].best_raw_similarity is not None
+        assert results[0].best_raw_similarity >= 0.6
+        assert results[0].best_sb_similarity is not None
+        assert results[0].best_sb_similarity < 0.6
+
+    def test_not_in_raw_word_order_swap_high_extracted_sim(self):
+        # Gold has subtitle first, PDF has it at the end (word-order swap).
+        # The fixed-window raw similarity may be low, but the extracted title
+        # has high similarity to the gold — evidence the content IS in the PDF.
+        # The split must use max(raw_sim, extr_sim) so this lands in
+        # "Present in PDF as different form" rather than "Absent from source PDF".
+        pdf_title = (
+            'Functional imaging of time on task and the involvement of '
+            'dopaminergic and cholinergic substrates in cognitive effort and reward'
+        )
+        gold = (
+            'Cognitive effort and reward. Functional imaging of time on task and '
+            'the involvement of dopaminergic and cholinergic substrates'
+        )
+        results = assign_failure_modes([gold], pdf_title, pdf_title)
+        assert results[0].mode == FailureMode.NOT_IN_RAW_TEXT
+        assert results[0].best_sb_similarity is not None
+        # Extracted sim should be high enough to rescue this from "Absent"
+        assert results[0].best_sb_similarity >= 0.6
+
     def test_not_in_raw_all_caps_extracted_has_high_similarity(self):
         # When gold is mixed-case and the extracted value is ALL CAPS, the
         # case-insensitive similarity must be high so the entry lands in
-        # "Extracted with different form" not "Absent from raw text".
+        # "Present in PDF as different form" not "Absent from source PDF".
         raw = (
             'IS AUDIO VISUAL METHOD BETTER THAN TRADITIONAL FOR MEDICAL STUDENTS?'
             ' - A SURVEY REPORT'

--- a/benchmarks/analyze_gold_failures/tests/test_modes.py
+++ b/benchmarks/analyze_gold_failures/tests/test_modes.py
@@ -8,7 +8,7 @@ RAW_TEXT = 'Introduction Methods Results Discussion Conclusion'
 SB_FIELD = 'Introduction | Methods | Results'
 
 
-class TestAssignFailureModes:
+class TestAssignFailureModes:  # pylint: disable=too-many-public-methods
     def test_correct_when_value_extracted_and_similar(self):
         results = assign_failure_modes(['Introduction'], RAW_TEXT, SB_FIELD)
         assert len(results) == 1
@@ -101,6 +101,101 @@ class TestAssignFailureModes:
         gold = 'Methoxs'  # 2 chars differ in a 7-char string
         results = assign_failure_modes([gold], raw, None)
         assert results[0].in_raw is False
+
+    def test_not_in_raw_shows_similar_extracted_value(self):
+        # Gold title differs from the extracted title by one extra word and a
+        # missing hyphen — the raw-text fuzzy check can't bridge that gap, so
+        # the result is NOT_IN_RAW_TEXT.  But the extracted value should appear
+        # as best_sb_match so the report can show what was actually extracted.
+        raw = (
+            'A Pan-respiratory Antiviral Chemotype Targeting '
+            'a Transient Host Multiprotein Complex'
+        )
+        gold = (
+            'A Pan-Respiratory Antiviral Chemotype Targeting '
+            'a Host Multi-Protein Complex'
+        )
+        sb_field = (
+            'A Pan-respiratory Antiviral Chemotype Targeting '
+            'a Transient Host Multiprotein Complex'
+        )
+        results = assign_failure_modes([gold], raw, sb_field)
+        assert results[0].mode == FailureMode.NOT_IN_RAW_TEXT
+        assert results[0].best_sb_match == sb_field
+        assert results[0].best_sb_similarity is not None
+        assert results[0].best_sb_similarity >= 0.8
+
+    def test_not_in_raw_stores_extracted_value_even_when_unrelated(self):
+        # The extracted field value is always stored so the report can show what
+        # was extracted.  The (low) similarity score tells the user it's unrelated.
+        raw = 'Some completely different text on this page'
+        gold = 'A Pan-Respiratory Antiviral Chemotype'
+        sb_field = 'Some completely different title'
+        results = assign_failure_modes([gold], raw, sb_field)
+        assert results[0].mode == FailureMode.NOT_IN_RAW_TEXT
+        assert results[0].best_sb_match == sb_field
+        assert results[0].best_sb_similarity is not None
+        assert results[0].best_sb_similarity < 0.5
+
+    def test_not_in_raw_best_sb_match_is_none_when_nothing_extracted(self):
+        # When sb_field is None (or empty), there's no extracted value to show.
+        raw = 'Some text in the document'
+        gold = 'A title never extracted'
+        results = assign_failure_modes([gold], raw, None)
+        assert results[0].mode == FailureMode.NOT_IN_RAW_TEXT
+        assert results[0].best_sb_match is None
+
+    def test_all_caps_title_is_not_not_in_raw_text(self):
+        # PDF rendering may produce ALL-CAPS titles.  Presence detection must be
+        # case-insensitive so these are not falsely classified as NOT_IN_RAW_TEXT.
+        raw = 'ETHNO-MEDICO BOTANICAL STUDY AMONG THE FOUR INDIGENOUS COMMUNITIES'
+        gold = 'Ethno-medico botanical study among the four indigenous communities'
+        sb_field = 'ETHNO-MEDICO BOTANICAL STUDY AMONG THE FOUR INDIGENOUS COMMUNITIES'
+        results = assign_failure_modes([gold], raw, sb_field)
+        assert results[0].in_raw is True
+        assert results[0].mode != FailureMode.NOT_IN_RAW_TEXT
+
+    def test_not_in_raw_all_caps_extracted_has_high_similarity(self):
+        # When gold is mixed-case and the extracted value is ALL CAPS, the
+        # case-insensitive similarity must be high so the entry lands in
+        # "Extracted with different form" not "Absent from raw text".
+        raw = (
+            'IS AUDIO VISUAL METHOD BETTER THAN TRADITIONAL FOR MEDICAL STUDENTS?'
+            ' - A SURVEY REPORT'
+        )
+        gold = (
+            'Is Audio Visual Method Better than Traditional for Medical Students?'
+            ' - A Better Survey Report'
+        )
+        sb_field = (
+            'IS AUDIO VISUAL METHOD BETTER THAN TRADITIONAL FOR MEDICAL STUDENTS?'
+            ' - A SURVEY REPORT'
+        )
+        results = assign_failure_modes([gold], raw, sb_field)
+        # Gold has "A Better Survey Report" but TEI has "A SURVEY REPORT" — genuinely absent.
+        assert results[0].mode == FailureMode.NOT_IN_RAW_TEXT
+        # But the extracted title is clearly the same document title, so similarity must be high.
+        assert results[0].best_sb_similarity is not None
+        assert results[0].best_sb_similarity >= 0.6
+
+    def test_inline_markup_in_raw_tei_is_found_in_raw(self):
+        # Title text split across <hi> elements must still be found in raw text.
+        # Without tag stripping the normalized string would have tag markup
+        # between the text fragments, breaking substring search.
+        raw = (
+            '<title level="a" type="main">'
+            '<hi rend="bold">Roles for the long non-coding RNA</hi>'
+            ' <hi rend="bold"><hi rend="italic">Pax6os1/PAX6-AS1</hi></hi>'
+            ' <hi rend="bold">in pancreatic beta cell identity and function</hi>'
+            '</title>'
+        )
+        gold = (
+            'Roles for the long non-coding RNA Pax6os1/PAX6-AS1'
+            ' in pancreatic beta cell identity and function'
+        )
+        results = assign_failure_modes([gold], raw, None)
+        assert results[0].in_raw is True
+        assert results[0].mode == FailureMode.EXTRACTION_FAILED
 
     def test_case_difference_in_sb_field_is_correct_not_extraction_failed(self):
         # Gold JATS: "Synthesis of PAV-431 Resin" (capital R)

--- a/benchmarks/analyze_gold_failures/tests/test_screenshots.py
+++ b/benchmarks/analyze_gold_failures/tests/test_screenshots.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from benchmarks.analyze_gold_failures._screenshots import _text_similarity
+
+
+class TestTextSimilarity:
+    def test_exact_match_scores_1(self):
+        assert _text_similarity('abc', 'abc') == 1.0
+
+    def test_substring_match_scores_1_regardless_of_element_length(self):
+        # Gold appears verbatim at the start of a much longer element text.
+        # The element also contains a translation and affiliation, but that
+        # should not reduce the score.
+        gold = 'debateonthepaperbynamoardealmeidafilho'
+        element = gold + 'debatesobreoartigodenaomardealme' + 'laboratoriodelascienciassociales'
+        assert _text_similarity(gold, element) == 1.0
+
+    def test_gold_as_suffix_scores_1(self):
+        assert _text_similarity('world', 'hello world') == 1.0
+
+    def test_absent_text_scores_0(self):
+        assert _text_similarity('acknowledgements', 'introduction methods results') == 0.0
+
+    def test_empty_gold_scores_0(self):
+        assert _text_similarity('', 'some element text') == 0.0
+
+    def test_empty_element_scores_0(self):
+        assert _text_similarity('some gold value', '') == 0.0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-testpaths = tests benchmarks/tests
+testpaths = tests benchmarks/tests benchmarks/analyze_gold_failures/tests
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')


### PR DESCRIPTION
Improve gold-label failure mode analysis: raw similarity, ALL CAPS fix, and screenshot scoring

part of https://github.com/eLifePathways/ScienceBeam2.0/issues/101

- Add best_raw_similarity (gold/PDF source text match score) alongside
  best_sb_similarity (gold/extracted match score), giving a two-dimensional
  view of each NOT_IN_RAW_TEXT failure — whether the gold value is absent
  from the source PDF or just rendered differently

- Fix ALL CAPS classification — presence detection and similarity scoring
  are now case-insensitive throughout, so ALL CAPS PDF titles are correctly
  identified as present and scored as CORRECT rather than PARTIAL_WRONG or
  NOT_IN_RAW_TEXT

- Improve NOT_IN_RAW_TEXT subsection split — use max(raw_sim, extr_sim)
  rather than raw similarity alone so word-order swaps are rescued into
  "Present in PDF as different form" when extracted similarity is high;
  both subsections now show the extracted value and its similarity for context

- Fix screenshot element scoring — _text_similarity previously penalised
  elements by total element length, causing figDesc elements that bundle
  an English title, Portuguese translation, and affiliation together to
  fall below the acceptance threshold even when the gold title appears
  verbatim inside them; score is now 1.0 for any verbatim substring match
  with ranking left to context (sibling) scoring