### PR TITLE
Make it easy to generate training data for a different mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ TRAINING_DATA_MODELS ?= segmentation header affiliation-address reference-segmen
 # symlink at data/generated-training-data or override the variable directly:
 #   make dev-generate-training-data TRAINING_DATA_OUTPUT=/path/to/output-repo
 SOURCE_TRAINING_CONFIG ?= benchmarks/training-source.yml
-SOURCE_TRAINING_DATA ?= data/source-training-data
 SOURCE_TRAINING_MODE ?= smoke
+SOURCE_TRAINING_DATA ?= data/source-training-data/$(SOURCE_TRAINING_MODE)
 SOURCE_TRAINING_SPLIT ?= train
 
 SHOW_FIELD ?=

--- a/benchmarks/training-source.yml
+++ b/benchmarks/training-source.yml
@@ -20,11 +20,17 @@ cc_by_corpora:
 #   ore: 199, scielo_preprints-jats: 1000
 sampling:
   smoke:
-    ore: 5
+    ore: 10
     scielo_preprints-jats: 10
   small:
-    ore: 20
+    ore: 25
+    scielo_preprints-jats: 25
+  medium:
+    ore: 50
     scielo_preprints-jats: 50
+  large:
+    ore: 100
+    scielo_preprints-jats: 100
   full:
     ore: null   # all records
     scielo_preprints-jats: null


### PR DESCRIPTION
Training data generated using:

```shell
make dev-fetch-training-source SOURCE_TRAINING_MODE=smoke
```

```shell
make dev-generate-training-data TRAINING_DATA_NUM_WORKERS=8 SOURCE_TRAINING_MODE=medium TRAINING_DATA_MODELS='reference-segmenter citation'
```